### PR TITLE
Add demand elasticity and price

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -173,7 +173,7 @@ function demand(H::Consumer, C::Commodity)
         return 0
     end
     d = D.demands[C]
-    return quantity(d)*reference_price(d)/total_quantity * get_variable(H)/get_variable(C) * ifelse(elasticity(D) != 1, (expenditure(D)*reference_price(d)/get_variable(C))^(elasticity(D)-1), 1)
+    return quantity(d)/total_quantity * get_variable(H)/get_variable(C) * ifelse(elasticity(D) != 1, (expenditure(D)*reference_price(d)/get_variable(C))^(elasticity(D)-1), 1)
 end
 
 

--- a/src/build.jl
+++ b/src/build.jl
@@ -173,7 +173,13 @@ function demand(H::Consumer, C::Commodity)
         return 0
     end
     d = D.demands[C]
-    return quantity(d)/total_quantity * get_variable(H)/get_variable(C)
+    return quantity(d)*reference_price(d)/total_quantity * get_variable(H)/get_variable(C)# * (expenditure(D)*reference_price(d)/get_variable(C))^(elasticity(D)-1)
+end
+
+
+function expenditure(D::ScalarDemand)
+    total_quantity = quantity(D)
+    return sum( quantity(d)/total_quantity * get_variable(commodity(d))/reference_price(d) for (_,d)∈demands(D))
 end
 
 ###########################
@@ -221,7 +227,7 @@ function build!(M::MPSGEModel)
     # This needs to be more elegant
     for (consumer,d) in M.demands
         var = get_variable(consumer)
-        set_start_value(var, quantity(d))
+        set_start_value(var, raw_quantity(d))
     end
 
     #Need to fix all parameter variables

--- a/src/build.jl
+++ b/src/build.jl
@@ -173,13 +173,14 @@ function demand(H::Consumer, C::Commodity)
         return 0
     end
     d = D.demands[C]
-    return quantity(d)*reference_price(d)/total_quantity * get_variable(H)/get_variable(C)# * (expenditure(D)*reference_price(d)/get_variable(C))^(elasticity(D)-1)
+    return quantity(d)*reference_price(d)/total_quantity * get_variable(H)/get_variable(C) * ifelse(elasticity(D) != 1, (expenditure(D)*reference_price(d)/get_variable(C))^(elasticity(D)-1), 1)
 end
 
 
 function expenditure(D::ScalarDemand)
     total_quantity = quantity(D)
-    return sum( quantity(d)/total_quantity * get_variable(commodity(d))/reference_price(d) for (_,d)∈demands(D))
+    σ = elasticity(D)
+    return sum( quantity(d)/total_quantity * (get_variable(commodity(d))/reference_price(d))^(1-σ) for (_,d)∈demands(D))^(1/(1-σ))
 end
 
 ###########################

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -94,8 +94,8 @@ macro production(model, sector, output, input)
 end
 
 
-macro demand(model, consumer, demands, endowments)
+macro demand(model, consumer, demands, endowments, kwargs...)
     constr_call = :(add_demand!($(esc(model)), $(esc(consumer)), $(esc(demands)), $(esc(endowments))))
-    #_add_kw_args(constr_call, kwargs)
+    _add_kw_args(constr_call, kwargs)
     return :($constr_call)
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -72,8 +72,8 @@ function add_production!(model::AbstractMPSGEModel, S::ScalarSector, input::Scal
     return P
 end
 
-function add_demand!(M::MPSGEModel,H::ScalarConsumer,demands::Vector{ScalarDem},endowments::Vector{ScalarEndowment})
-    P = ScalarDemand(H,demands,endowments)
+function add_demand!(M::MPSGEModel,H::ScalarConsumer,demands::Vector{ScalarDem},endowments::Vector{ScalarEndowment};elasticity::Union{Real,ScalarParameter} = 1)
+    P = ScalarDemand(H,demands,endowments; elasticity = elasticity)
     M.demands[H] = P
     return P
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,14 +3,14 @@ using Test
 
 @testset "MPSGE_MP.jl" begin
 
-    #include("test_pruning.jl")
-    #include("test_Benchmark-Theta.jl")
-    #include("test_jpmge.jl")
-    #include("test_twobytwo_ces_functional.jl")
-    #include("test_twobytwo_functional.jl")
-    #include("test_twobytwo_indexed.jl")
-    #include("test_twobytwo_macro.jl")
+    include("test_pruning.jl")
+    include("test_Benchmark-Theta.jl")
+    include("test_jpmge.jl")
+    include("test_twobytwo_ces_functional.jl")
+    include("test_twobytwo_functional.jl")
+    include("test_twobytwo_indexed.jl")
+    include("test_twobytwo_macro.jl")
     include("test_twobytwo_Price.jl")
-    #include("test_twobytwo_wTaxes.jl")
+    include("test_twobytwo_wTaxes.jl")
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,14 +3,14 @@ using Test
 
 @testset "MPSGE_MP.jl" begin
 
-    include("test_pruning.jl")
-    include("test_Benchmark-Theta.jl")
-    include("test_jpmge.jl")
-    include("test_twobytwo_ces_functional.jl")
-    include("test_twobytwo_functional.jl")
-    include("test_twobytwo_indexed.jl")
-    include("test_twobytwo_macro.jl")
+    #include("test_pruning.jl")
+    #include("test_Benchmark-Theta.jl")
+    #include("test_jpmge.jl")
+    #include("test_twobytwo_ces_functional.jl")
+    #include("test_twobytwo_functional.jl")
+    #include("test_twobytwo_indexed.jl")
+    #include("test_twobytwo_macro.jl")
     include("test_twobytwo_Price.jl")
-    include("test_twobytwo_wTaxes.jl")
+    #include("test_twobytwo_wTaxes.jl")
 
 end

--- a/test/test_jpmge.jl
+++ b/test/test_jpmge.jl
@@ -163,3 +163,337 @@
     @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D PF(\"labor\")=1"] # 6.01862449771691
         
 end
+
+
+
+
+@testset "JPMGE Demand Elasticities" begin
+    using XLSX, MPSGE_MP.JuMP.Containers
+    import JuMP
+    #A replication of the JPMGE from https://www.gams.com/34/docs/UG_MPSGE_Intro.html#UG_MPSGE_Intro_Appendix_jpmge
+    # Re-running the model and tests as checks on different Demand elasticities - here with Demand elasticity = 0 (Leontief)
+    M = MPSGEModel()
+    # All indexes and data as above, added for structure as @testitem
+    goods = [:g1, :g2]
+    factors = [:l, :k]
+    secs = [:s1, :s2]
+    make0 = DenseAxisArray(Float64[6 2; 2 10], goods, secs)
+    use0 = DenseAxisArray(Float64[4 2; 2 6], goods, secs)
+    fd0 = DenseAxisArray(Float64[1 3; 1 1], factors, secs)
+    c0 = DenseAxisArray(Float64[2, 4], goods)
+    e0 = DenseAxisArray(Float64[sum(fd0[f,:]) for f in factors], factors)
+
+    
+    @parameter(M, endow, e0, index = (factors,))
+
+    @sector(M, X, index = (secs,))
+
+    @commodity(M, P, index = (goods,))
+    @commodity(M, PF, index = (factors,))
+
+    @consumer(M, Y)
+
+
+    for j∈secs
+        @production(M, X[j],
+            ScalarNest(:t; elasticity = 1, children = [
+                ScalarOutput(P[i], make0[i,j]) for i∈goods
+            ]),
+            ScalarNest(:s; elasticity = 1, children = [
+                [ScalarInput(P[i], use0[i,j]) for i∈goods];
+                [ScalarInput(PF[f],fd0[f,j] ) for f∈factors]
+            ])
+        )
+    end
+
+    @demand(M, Y, 
+        [ScalarDem(P[i], c0[i]) for i∈goods],
+        [ScalarEndowment(PF[j], endow[j]) for j∈factors],
+        elasticity = 0
+    );
+
+
+    #@demand(m, Y, 0., [Demand(P[i], c0[i]) for i in goods], [Endowment(PF[:k], :($(endow[:k]) * $(e0[:k]))), Endowment(PF[:l], :($(endow[:l]) * $(e0[:l])))])
+
+
+
+    solve!(M)
+
+    gams_results = XLSX.readxlsx(joinpath(@__DIR__, "MPSGEresults.xlsx"))
+    a_table = gams_results["JPMGE"][:]  # Generated from JPMGE_MPSGE
+    two_by_two_jpmge = DenseAxisArray(a_table[2:end,3:end],string.(a_table[2:end,1],".",a_table[2:end,2]),a_table[1,3:end])
+
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","benchmark"] # 1.
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","benchmark"] # 1.
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","benchmark"] # 1.
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","benchmark"] # 1.
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","benchmark"] # 1.
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","benchmark"] # 1.
+    @test value(Y) ≈ two_by_two_jpmge["Y._","benchmark"] # 6.
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","benchmark"] # 2.
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","benchmark"] # 4.
+    #Implicit Variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","benchmark"] # 6.
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","benchmark"] # 2.
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","benchmark"] # 2.
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","benchmark"] # 10.
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","benchmark"] # 1.
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","benchmark"] # 1.
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","benchmark"] # 3.
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","benchmark"] # 1.
+    #Separate column in GAMS results bc of display limitation
+    @test value(compensated_demand(X[:s1], P[:g1],:s)) ≈ two_by_two_jpmge["g1.s1","D benchmark"] # 4.
+    @test value(compensated_demand(X[:s2], P[:g1],:s)) ≈ two_by_two_jpmge["g1.s2","D benchmark"] # 2.
+    @test value(compensated_demand(X[:s1], P[:g2],:s)) ≈ two_by_two_jpmge["g2.s1","D benchmark"] # 2.
+    @test value(compensated_demand(X[:s2], P[:g2],:s)) ≈ two_by_two_jpmge["g2.s2","D benchmark"] # 6.
+
+    #Counter-factual 1, labour supply increased by 10%
+    set_value!(endow[:l], 1.1*value(endow[:l]))
+    
+    fix(Y, 6.4)
+
+    solve!(M)
+    
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","D_elas=0,Y=6.4"] # 1.00695565465906
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","D_elas=0,Y=6.4"] # 1.09465569946758
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","D_elas=0,Y=6.4"] # 1.01368184594902
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","D_elas=0,Y=6.4"] # 0.994372399169793
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","D_elas=0,Y=6.4"] # 0.975465157228405
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","D_elas=0,Y=6.4"] # 1.05397665409715
+    @test value(Y) ≈ two_by_two_jpmge["Y._","D_elas=0,Y=6.4"] # 6.4
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","D_elas=0,Y=6.4"] # 2.13160911430573
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","D_elas=0,Y=6.4"] # 4.26321822861147
+    
+    # Implicit variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","D_elas=0,Y=6.4"]  # 6.02850291751314
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","D_elas=0,Y=6.4"] # 1.97122234273858
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","D_elas=0,Y=6.4"] # 2.03220726447235
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","D_elas=0,Y=6.4"] # 9.967480532769
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","D_elas=0,Y=6.4"] # 1.03426465263408
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","D_elas=0,Y=6.4"] # 0.957221517265679
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","D_elas=0,Y=6.4"] # 3.06812576890585
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","D_elas=0,Y=6.4"] # 0.946526273906878
+    @test value(compensated_demand(X[:s1], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s1","D D_elas=0,Y=6.4"] # 3.98108789667806
+    @test value(compensated_demand(X[:s2], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s2","D D_elas=0,Y=6.4"] # 1.96830316962702
+    @test value(compensated_demand(X[:s1], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s1","D D_elas=0,Y=6.4"] # 2.02919777910129
+    @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D D_elas=0,Y=6.4"] # 6.01957533829582
+        
+
+
+    # Counter-factual 2, use Price of good 1 as the numeraire
+    unfix(Y)
+    fix(P[:g1], 1)
+    solve!(M)
+    
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","D_elas=0,P(\"g1\")=1"] atol=1.0e-7# 1.00695567662299
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","D_elas=0,P(\"g1\")=1"] # 1.09465569446489
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","D_elas=0,P(\"g1\")=1"] # 1
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","D_elas=0,P(\"g1\")=1"] # 0.980951166489968
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","D_elas=0,P(\"g1\")=1"] atol=1.0e-7# 0.96229910684127
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","D_elas=0,P(\"g1\")=1"] # 1.0397509357684
+    @test value(Y) ≈ two_by_two_jpmge["Y._","D_elas=0,P(\"g1\")=1"] atol=1.0e-6# 6.31361794163839
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","D_elas=0,P(\"g1\")=1"] # 2.13160909167667
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","D_elas=0,P(\"g1\")=1"] # 4.26321818335335
+    
+    # Implicit variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","D_elas=0,P(\"g1\")=1"]  # 6.02850293214301
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","D_elas=0,P(\"g1\")=1"] # 1.97122232782462
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","D_elas=0,P(\"g1\")=1"] # 2.03220728128503
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","D_elas=0,P(\"g1\")=1"] # 9.96748051562983
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","D_elas=0,P(\"g1\")=1"] atol=1.0e-7 # 1.0342646699325
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","D_elas=0,P(\"g1\")=1"] # 0.957221517072259
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","D_elas=0,P(\"g1\")=1"] # 3.06812580456063
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","D_elas=0,P(\"g1\")=1"] # 0.94652626888426
+    @test value(compensated_demand(X[:s1], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s1","D D_elas=0,P(\"g1\")=1"] # 3.98108787245412
+    @test value(compensated_demand(X[:s2], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s2","D D_elas=0,P(\"g1\")=1"] # 1.96830314760356
+    @test value(compensated_demand(X[:s1], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s1","D D_elas=0,P(\"g1\")=1"] # 2.02919778703114
+    @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D D_elas=0,P(\"g1\")=1"] # 6.0195753310938
+                
+    # Counter-factual 3, use price of labour (wages) as the numeraire
+    unfix(P[:g1])
+    fix(PF[:l], 1)
+    solve!(M)
+
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","D_elas=0,PF(\"l\")=1"] # 1.00695565465863
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","D_elas=0,PF(\"l\")=1"] # 1.09465569946539
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","D_elas=0,PF(\"l\")=1"] # 1.03917791264692
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","D_elas=0,PF(\"l\")=1"] # 1.01938279578823
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","D_elas=0,PF(\"l\")=1"] # 1
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","D_elas=0,PF(\"l\")=1"] # 1.08048621345859
+    @test value(Y) ≈ two_by_two_jpmge["Y._","D_elas=0,PF(\"l\")=1"] # 6.56097242691719
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","D_elas=0,PF(\"l\")=1"] # 2.13160911430459
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","D_elas=0,PF(\"l\")=1"] # 4.26321822860918
+        
+    # Implicit variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","D_elas=0,PF(\"l\")=1"]  # 6.02850291751269
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","D_elas=0,PF(\"l\")=1"] # 1.97122234273905
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","D_elas=0,PF(\"l\")=1"] # 2.03220726447182
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","D_elas=0,PF(\"l\")=1"] # 9.96748053276953
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","D_elas=0,PF(\"l\")=1"] # 1.03426465263337
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","D_elas=0,PF(\"l\")=1"] # 0.957221517267422
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","D_elas=0,PF(\"l\")=1"] # 3.06812576890445
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","D_elas=0,PF(\"l\")=1"] # 0.946526273908822
+    @test value(compensated_demand(X[:s1], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s1","D D_elas=0,PF(\"l\")=1"] # 3.98108789667772
+    @test value(compensated_demand(X[:s2], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s2","D D_elas=0,PF(\"l\")=1"] # 1.96830316962732
+    @test value(compensated_demand(X[:s1], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s1","D D_elas=0,PF(\"l\")=1"] # 2.02919777910049
+    @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D D_elas=0,PF(\"l\")=1"] # 6.01957533829483
+            
+
+
+    #A replication of the JPMGE from https://www.gams.com/34/docs/UG_MPSGE_Intro.html#UG_MPSGE_Intro_Appendix_jpmge
+    # Re-running the model and tests as checks on different Demand elasticities - here with Demand elasticity = 2. (A CES example)
+    M = MPSGEModel()
+    goods = [:g1, :g2]
+    factors = [:l, :k]
+    secs = [:s1, :s2]
+    make0 = DenseAxisArray(Float64[6 2; 2 10], goods, secs)
+    use0 = DenseAxisArray(Float64[4 2; 2 6], goods, secs)
+    fd0 = DenseAxisArray(Float64[1 3; 1 1], factors, secs)
+    c0 = DenseAxisArray(Float64[2, 4], goods)
+    e0 = DenseAxisArray(Float64[sum(fd0[f,:]) for f in factors], factors)
+
+    # All indices and data as above
+    @parameter(M, endow, e0, index = (factors,))
+
+    @sector(M, X, index = (secs,))
+
+    @commodity(M, P, index = (goods,))
+    @commodity(M, PF, index = (factors,))
+
+    @consumer(M, Y)
+
+
+    for j∈secs
+        @production(M, X[j],
+            ScalarNest(:t; elasticity = 1, children = [
+                ScalarOutput(P[i], make0[i,j]) for i∈goods
+            ]),
+            ScalarNest(:s; elasticity = 1, children = [
+                [ScalarInput(P[i], use0[i,j]) for i∈goods];
+                [ScalarInput(PF[f],fd0[f,j] ) for f∈factors]
+            ])
+        )
+    end
+
+    @demand(M, Y, 
+        [ScalarDem(P[i], c0[i]) for i∈goods],
+        [ScalarEndowment(PF[j], endow[j]) for j∈factors],
+        elasticity = 2
+    );
+
+    solve!(M)
+
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","benchmark"] # 1.
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","benchmark"] # 1.
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","benchmark"] # 1.
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","benchmark"] # 1.
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","benchmark"] # 1.
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","benchmark"] # 1.
+    @test value(Y) ≈ two_by_two_jpmge["Y._","benchmark"] # 6.
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","benchmark"] # 2.
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","benchmark"] # 4.
+    #Implicit Variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","benchmark"] # 6.
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","benchmark"] # 2.
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","benchmark"] # 2.
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","benchmark"] # 10.
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","benchmark"] # 1.
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","benchmark"] # 1.
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","benchmark"] # 3.
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","benchmark"] # 1.
+    #Separate column in GAMS results bc of display limitation
+    @test value(compensated_demand(X[:s1], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s1","D benchmark"] # 4.
+    @test value(compensated_demand(X[:s2], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s2","D benchmark"] # 2.
+    @test value(compensated_demand(X[:s1], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s1","D benchmark"] # 2.
+    @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D benchmark"] # 6.
+
+    #Counter-factual 1, labour supply increased by 10%
+    set_value!(endow[:l], 1.1*value(endow[:l]))
+    fix(Y, 6.4)
+
+    solve!(M)
+
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","D_elas=2,Y=6.4"] # 0.987856533434743
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","D_elas=2,Y=6.4"] # 1.10437048613336
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","D_elas=2,Y=6.4"] # 1.01249987524683
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","D_elas=2,Y=6.4"] # 0.994953167286117
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","D_elas=2,Y=6.4"] # 0.977738693937376
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","D_elas=2,Y=6.4"] # 1.04897487333719
+    @test value(Y) ≈ two_by_two_jpmge["Y._","D_elas=2,Y=6.4"] # 6.4
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","D_elas=2,Y=6.4"] # 2.08251175868133
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","D_elas=2,Y=6.4"] # 4.31322523032984
+        
+    # Implicit variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","D_elas=2,Y=6.4"]  # 6.02593709632531
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","D_elas=2,Y=6.4"] # 1.97383569994486
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","D_elas=2,Y=6.4"] # 2.02926314124557
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","D_elas=2,Y=6.4"] # 9.97047920201986
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","D_elas=2,Y=6.4"] # 1.03109535932841
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","D_elas=2,Y=6.4"] # 0.96107338276594
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","D_elas=2,Y=6.4"] # 3.06185809486106
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","D_elas=2,Y=6.4"] # 0.95130881612284
+    @test value(compensated_demand(X[:s1], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s1","D D_elas=2,Y=6.4"] # 3.98278302882309
+    @test value(compensated_demand(X[:s2], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s2","D D_elas=2,Y=6.4"] # 1.97115885007637
+    @test value(compensated_demand(X[:s1], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s1","D D_elas=2,Y=6.4"] # 2.02651112253757
+    @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D D_elas=2,Y=6.4"] # 6.01776492225618
+            
+    # Counter-factual 2, use Price of good 1 as the numeraire
+    unfix(Y)
+    fix(P[:g1], 1)
+    solve!(M)
+
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","D_elas=2,P(\"g1\")=1"] # 0.987856539834064
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","D_elas=2,P(\"g1\")=1"] # 1.10437048704423
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","D_elas=2,P(\"g1\")=1"] # 1
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","D_elas=2,P(\"g1\")=1"] # 0.982669909969397
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","D_elas=2,P(\"g1\")=1"] # 0.965667951333231
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","D_elas=2,P(\"g1\")=1"] # 1.03602468782685
+    @test value(Y) ≈ two_by_two_jpmge["Y._","D_elas=2,P(\"g1\")=1"] # 6.32098836151992
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","D_elas=2,P(\"g1\")=1"] atol=1.0e-7 # 2.0825117266148
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","D_elas=2,P(\"g1\")=1"] # 4.31322521622455
+    
+    # Implicit variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","D_elas=2,P(\"g1\")=1"]  # 6.025937105223
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","D_elas=2,P(\"g1\")=1"] # 1.97383569089024
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","D_elas=2,P(\"g1\")=1"] # 2.02926315143946
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","D_elas=2,P(\"g1\")=1"] # 9.97047919164619
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","D_elas=2,P(\"g1\")=1"] # 1.03109536963407
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","D_elas=2,P(\"g1\")=1"] # 0.961073384566025
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","D_elas=2,P(\"g1\")=1"] # 3.0618581162154
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","D_elas=2,P(\"g1\")=1"] # 0.951308815031151
+    @test value(compensated_demand(X[:s1], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s1","D D_elas=2,P(\"g1\")=1"] # 3.98278301289486
+    @test value(compensated_demand(X[:s2], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s2","D D_elas=2,P(\"g1\")=1"] # 1.97115883623916
+    @test value(compensated_demand(X[:s1], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s1","D D_elas=2,P(\"g1\")=1"] # 2.02651112672153
+    @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D D_elas=2,P(\"g1\")=1"] # 6.01776491650351
+                    
+    # Counter-factual 3, use price of labour (wages) as the numeraire
+    unfix(P[:g1])
+    fix(PF[:l], 1)
+    solve!(M)
+
+    @test value(X[:s1]) ≈ two_by_two_jpmge["X.s1","D_elas=2,PF(\"l\")=1"] # 0.987856533434657
+    @test value(X[:s2]) ≈ two_by_two_jpmge["X.s2","D_elas=2,PF(\"l\")=1"] # 1.10437048613261
+    @test value(P[:g1]) ≈ two_by_two_jpmge["P.g1","D_elas=2,PF(\"l\")=1"] # 1.03555262927087
+    @test value(P[:g2]) ≈ two_by_two_jpmge["P.g2","D_elas=2,PF(\"l\")=1"] # 1.01760641514489
+    @test value(PF[:l]) ≈ two_by_two_jpmge["PF.labor","D_elas=2,PF(\"l\")=1"] # 1
+    @test value(PF[:k]) ≈ two_by_two_jpmge["PF.capital","D_elas=2,PF(\"l\")=1"] # 1.07285809576816
+    @test value(Y) ≈ two_by_two_jpmge["Y._","D_elas=2,PF(\"l\")=1"] # 6.54571619153632
+    @test value(demand(Y, P[:g1])) ≈ two_by_two_jpmge["PY.g1","D_elas=2,PF(\"l\")=1"] # 2.08251175868083
+    @test value(demand(Y, P[:g2])) ≈ two_by_two_jpmge["PY.g2","D_elas=2,PF(\"l\")=1"] # 4.31322523032828
+        # Implicit variables
+    @test value(compensated_demand(X[:s1], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s1","D_elas=2,PF(\"l\")=1"]  # 6.02593709632522
+    @test value(compensated_demand(X[:s1], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s1","D_elas=2,PF(\"l\")=1"] # 1.97383569994494
+    @test value(compensated_demand(X[:s2], P[:g1], :t)) ≈ -two_by_two_jpmge["g1.s2","D_elas=2,PF(\"l\")=1"] # 2.02926314124547
+    @test value(compensated_demand(X[:s2], P[:g2], :t)) ≈ -two_by_two_jpmge["g2.s2","D_elas=2,PF(\"l\")=1"] # 9.97047920201996
+    @test value(compensated_demand(X[:s1], PF[:l])) ≈ two_by_two_jpmge["labor.s1","D_elas=2,PF(\"l\")=1"] # 1.03109535932825
+    @test value(compensated_demand(X[:s1], PF[:k])) ≈ two_by_two_jpmge["capital.s1","D_elas=2,PF(\"l\")=1"] # 0.961073382766426
+    @test value(compensated_demand(X[:s2], PF[:l])) ≈ two_by_two_jpmge["labor.s2","D_elas=2,PF(\"l\")=1"] # 3.06185809486075
+    @test value(compensated_demand(X[:s2], PF[:k])) ≈ two_by_two_jpmge["capital.s2","D_elas=2,PF(\"l\")=1"] # 0.951308816123371
+    @test value(compensated_demand(X[:s1], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s1","D D_elas=2,PF(\"l\")=1"] # 3.98278302882293
+    @test value(compensated_demand(X[:s2], P[:g1], :s)) ≈ two_by_two_jpmge["g1.s2","D D_elas=2,PF(\"l\")=1"] # 1.97115885007639
+    @test value(compensated_demand(X[:s1], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s1","D D_elas=2,PF(\"l\")=1"] # 2.02651112253737
+    @test value(compensated_demand(X[:s2], P[:g2], :s)) ≈ two_by_two_jpmge["g2.s2","D D_elas=2,PF(\"l\")=1"] # 6.0177649222559
+    
+
+end
+    

--- a/test/test_twobytwo_Price.jl
+++ b/test/test_twobytwo_Price.jl
@@ -508,7 +508,7 @@ end
             ScalarOutput(PX, 80, taxes=[Tax(RA, otax)])
         ]),
         ScalarNest(:s; elasticity = esub_x, children = [
-            ScalarInput(PL, 30, taxes=[Tax(RA, itax)], reference_price=1.2), 
+            ScalarInput(PL, 30, taxes=[Tax(RA, itax)]), 
             ScalarInput(PK, 50)
         ])
     )
@@ -541,7 +541,8 @@ end
         [
             ScalarEndowment(PL, endow), 
             ScalarEndowment(PK, 80)
-        ]
+        ],
+        elasticity = esub_ra
     )
 
 
@@ -576,7 +577,7 @@ end
     # # set_fixed!(RA, true)
 
 
-#=
+
 
     # # algebraic_version(m)
     solve!(m)
@@ -627,6 +628,7 @@ end
     @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","eRA=.6"]#  128.8306562
     @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","eRA=.6"]#  10.4162285
 
+    
     set_value!(pr_Ud, 3.)
     solve!(m)
     # pr_Ud=3
@@ -650,6 +652,8 @@ end
     @test value(RA) ≈ two_by_two_PriceinDemand["RA","pr_Ud=3"]#  139.2001931
     @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","pr_Ud=3"]#  133.6355722
     @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","pr_Ud=3"]#  5.5900505
+
+    
 
     set_value!(esub_ra, .5)
     set_value!(pr_Ud,  2.)
@@ -750,6 +754,7 @@ end
     @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","Itax=0.1"]#  123.8062579
     @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","Itax=0.1"]#  15.4017044
 
+    
     set_value!(otax, 0.1)
     solve!(m)
     # Otax=0.1
@@ -774,5 +779,5 @@ end
     @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","Otax=0.1"]#  122.9999725
     @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","Otax=0.1"]#  15.9343683
 
-    =#
+    
 end

--- a/test/test_twobytwo_Price.jl
+++ b/test/test_twobytwo_Price.jl
@@ -1,3 +1,5 @@
+
+#=
 @testset "TWOBYTWO (functional version , with non-1 prices in Inputs)" begin
     using XLSX, MPSGE_MP.JuMP.Containers
     import JuMP
@@ -459,270 +461,318 @@ end
 end
 
 
-#=
+
+=#
 
 @testset "TWOBYTWO (functional version , with non-1 prices in Demand)" begin
     using XLSX, MPSGE_MP.JuMP.Containers
     import JuMP
 
-gams_results = XLSX.readxlsx(joinpath(@__DIR__, "MPSGEresults.xlsx"))
-a_table = gams_results["two_by_two_PriceinDem"][:]  # Generated with TwoByTwo_wPriceeOutputs.gms
-two_by_two_PriceinDemand = DenseAxisArray(a_table[2:end,2:end],a_table[2:end,1],a_table[1,2:end])
+    gams_results = XLSX.readxlsx(joinpath(@__DIR__, "MPSGEresults.xlsx"))
+    a_table = gams_results["two_by_two_PriceinDem"][:]  # Generated with TwoByTwo_wPriceeOutputs.gms
+    two_by_two_PriceinDemand = DenseAxisArray(a_table[2:end,2:end],a_table[2:end,1],a_table[1,2:end])
 
-m = MPSGEModel()
-endow  = add!(m, Parameter(:endow, value=1.))
-esub_x = add!(m, Parameter(:esub_x, value=1.))
-esub_y=add!(m, Parameter(:esub_y, value=1.))
-esub_u=add!(m, Parameter(:esub_u, value=1.))
-esub_ra=add!(m, Parameter(:esub_ra, value=1.))
-pr_U = add!(m, Parameter(:pr_U, value=1.0))
-pr_Ud=add!(m, Parameter(:pr_Ud, value=1.0))
-otax=add!(m, Parameter(:otax, value=0.))
-itax=add!(m, Parameter(:itax, value=0.))
+    m = MPSGEModel()
 
-X = add!(m, Sector(:X))
-Y = add!(m, Sector(:Y))
-U = add!(m, Sector(:U))
+    @parameters(m, begin
+        endow, 54
+        esub_x, 1
+        esub_y, 1
+        esub_u, 1
+        otax, 0
+        itax, 0
+        esub_ra, 1
+        pr_U, 1
+        pr_Ud, 1
+    end)
 
-PX = add!(m, Commodity(:PX))
-PY = add!(m, Commodity(:PY))
-PU = add!(m, Commodity(:PU))
-PL = add!(m, Commodity(:PL))#, benchmark=1.2))
-PK = add!(m, Commodity(:PK))
 
-RA = add!(m, Consumer(:RA, benchmark=134.))
+    @sectors(m, begin
+        X
+        Y
+        U
+    end)
 
-add!(m, Production(X, 0, :(1.0 * $esub_x), [ScalarOutput(PX, 80, taxes=[Tax(:($otax*1.),RA)])], [ScalarInput(PL, 30, taxes=[Tax(:($itax*1.),RA)]), ScalarInput(PK, 50)]))
-# add!(m, Production(Y, 0, :(1.0 * $esub_y), [ScalarOutput(PY, 54)], [ScalarInput(PL, 20), ScalarInput(PK, 30)]))
-# add!(m, Production(Y, 0, :(1.0 * $esub_y), [ScalarOutput(PY, 54)],                         [ScalarInput(PL, 20, [Tax(:($itax*1.),RA)], 1.2), ScalarInput(PK, 30)]))
-add!(m, Production(Y, 0, :(1.0 * $esub_y), [ScalarOutput(PY, 54)], [ScalarInput(PL, 24,), ScalarInput(PK, 30)]))
-add!(m, Production(U, 0, :(1.0 * $esub_u), [ScalarOutput(PU, 124., price=1.)], [ScalarInput(PX, 80), ScalarInput(PY, 44)]))
+    @commodities(m, begin
+        PX
+        PY
+        PU
+        PL
+        PK
+    end)
 
-add!(m, DemandFunction(RA, :($esub_ra*1.), [ScalarDem(PU,124., :($pr_Ud*1.)), ScalarDem(PY,10, 1.0)], [ScalarEndowment(PL, :(54. *$endow)), ScalarEndowment(PK, 80)]))
+    @consumer(m, RA)
 
-fix(PU, 1)
-solve!(m, cumulative_iteration_limit=0)
-# benchmark
-@test value(X) ≈ two_by_two_PriceinDemand["X","benchmark"]#  1
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","benchmark"]#  1
-@test value(U) ≈ two_by_two_PriceinDemand["U","benchmark"]#  1
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","benchmark"]#  1
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","benchmark"]#  1
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","benchmark"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","benchmark"]#  1
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","benchmark"]#  1
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","benchmark"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","benchmark"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","benchmark"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","benchmark"]#  30
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","benchmark"]#  50
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","benchmark"]#  24
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","benchmark"]#  30
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","benchmark"]#  80
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","benchmark"]#  44
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","benchmark"]#  134
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","benchmark"]#  124
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","benchmark"]#  10
+    @production(m, X,
+        ScalarNest(:t; elasticity = 0, children = [
+            ScalarOutput(PX, 80, taxes=[Tax(RA, otax)])
+        ]),
+        ScalarNest(:s; elasticity = esub_x, children = [
+            ScalarInput(PL, 30, taxes=[Tax(RA, itax)], reference_price=1.2), 
+            ScalarInput(PK, 50)
+        ])
+    )
 
-set_value!(endow,1.1)
-# # set_value!(RA,172.2046917)
-# # set_fixed!(RA, true)
+    @production(m, Y,
+        ScalarNest(:t; elasticity = 0, children = [
+            ScalarOutput(PY, 54)
+        ]),
+        ScalarNest(:s; elasticity = esub_y, children = [
+            ScalarInput(PL, 24,), 
+            ScalarInput(PK, 30)
+        ])
+    )
 
-# # algebraic_version(m)
-solve!(m)
+    @production(m, U,
+        ScalarNest(:t; elasticity = 0, children = [
+            ScalarOutput(PU, 124.)
+        ]),
+        ScalarNest(:s; elasticity = esub_u, children = [
+            ScalarInput(PX, 80), 
+            ScalarInput(PY, 44)
+        ])
+    )
 
-# RA=157
-@test value(X) ≈ two_by_two_PriceinDemand["X","RA=157"]#  1.0363877
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","RA=157"]#  1.0432701
-@test value(U) ≈ two_by_two_PriceinDemand["U","RA=157"]#  1.0388246
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","RA=157"]#  1.0023514
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","RA=157"]#  0.9957389
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","RA=157"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","RA=157"]#  0.944386
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","RA=157"]#  1.0388246
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","RA=157"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","RA=157"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","RA=157"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","RA=157"]#  31.8413654
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","RA=157"]#  48.2444931
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","RA=157"]#  25.3050487
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","RA=157"]#  28.7557372
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","RA=157"]#  79.812333
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","RA=157"]#  44.1882892
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","RA=157"]#  139.2025004
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","RA=157"]#  128.8142541
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","RA=157"]#  10.4327007
+    @demand(m, RA, 
+        [
+            ScalarDem(PU,124; reference_price = pr_Ud)
+            ScalarDem(PY, 10)    
+        ],
+        [
+            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PK, 80)
+        ]
+    )
 
-set_value!(esub_ra, 0.6)
-solve!(m)
-# eRA=.6
-@test value(X) ≈ two_by_two_PriceinDemand["X","eRA=.6"]#  1.0365191
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","eRA=.6"]#  1.0430741
-@test value(U) ≈ two_by_two_PriceinDemand["U","eRA=.6"]#  1.0389569
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","eRA=.6"]#  1.0023519
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","eRA=.6"]#  0.995738
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","eRA=.6"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","eRA=.6"]#  0.9443736
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","eRA=.6"]#  1.0388337
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","eRA=.6"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","eRA=.6"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","eRA=.6"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","eRA=.6"]#  31.8418024
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","eRA=.6"]#  48.2440959
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","eRA=.6"]#  25.3053574
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","eRA=.6"]#  28.7554566
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","eRA=.6"]#  79.8122898
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","eRA=.6"]#  44.1883326
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","eRA=.6"]#  139.2024902
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","eRA=.6"]#  128.8306562
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","eRA=.6"]#  10.4162285
 
-set_value!(pr_Ud, 3.)
-solve!(m)
-# pr_Ud=3
-@test value(X) ≈ two_by_two_PriceinDemand["X","pr_Ud=3"]#  1.075007
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","pr_Ud=3"]#  0.9856634
-@test value(U) ≈ two_by_two_PriceinDemand["U","pr_Ud=3"]#  1.0777062
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","pr_Ud=3"]#  1.0025108
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","pr_Ud=3"]#  0.9954509
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","pr_Ud=3"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","pr_Ud=3"]#  0.9407323
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","pr_Ud=3"]#  1.0415087
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","pr_Ud=3"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","pr_Ud=3"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","pr_Ud=3"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","pr_Ud=3"]#  31.9701227
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","pr_Ud=3"]#  48.1278184
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","pr_Ud=3"]#  25.395985
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","pr_Ud=3"]#  28.6733343
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","pr_Ud=3"]#  79.7996352
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","pr_Ud=3"]#  44.2010741
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","pr_Ud=3"]#  139.2001931
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","pr_Ud=3"]#  133.6355722
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","pr_Ud=3"]#  5.5900505
+    build!(m)
 
-set_value!(esub_ra, .5)
-set_value!(pr_Ud,  2.)
-solve!(m)
-# prU2,eRA.5
-@test value(X) ≈ two_by_two_PriceinDemand["X","prU2,eRA.5"]#  1.0595609
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","prU2,eRA.5"]#  1.0087068
-@test value(U) ≈ two_by_two_PriceinDemand["U","prU2,eRA.5"]#  1.0621537
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","prU2,eRA.5"]#  1.002447
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","prU2,eRA.5"]#  0.9955662
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","prU2,eRA.5"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","prU2,eRA.5"]#  0.9421925
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","prU2,eRA.5"]#  1.0404339
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","prU2,eRA.5"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","prU2,eRA.5"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","prU2,eRA.5"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","prU2,eRA.5"]#  31.9185419
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","prU2,eRA.5"]#  48.1744684
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","prU2,eRA.5"]#  25.3595604
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","prU2,eRA.5"]#  28.706277
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","prU2,eRA.5"]#  79.8047156
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","prU2,eRA.5"]#  44.1959582
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","prU2,eRA.5"]#  139.2009488
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","prU2,eRA.5"]#  131.7070569
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","prU2,eRA.5"]#  7.5272667
+    fix(PU, 1)
+    solve!(m, cumulative_iteration_limit=0)
+    # benchmark
+    @test value(X) ≈ two_by_two_PriceinDemand["X","benchmark"]#  1
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","benchmark"]#  1
+    @test value(U) ≈ two_by_two_PriceinDemand["U","benchmark"]#  1
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","benchmark"]#  1
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","benchmark"]#  1
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","benchmark"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","benchmark"]#  1
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","benchmark"]#  1
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","benchmark"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","benchmark"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","benchmark"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","benchmark"]#  30
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","benchmark"]#  50
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","benchmark"]#  24
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","benchmark"]#  30
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","benchmark"]#  80
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","benchmark"]#  44
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","benchmark"]#  134
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","benchmark"]#  124
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","benchmark"]#  10
 
-set_value!(pr_Ud, 0.5)
-set_value!(esub_ra, 0.6)
-solve!(m)
-# prUd.5,e.6
-@test value(X) ≈ two_by_two_PriceinDemand["X","prUd.5,e.6"]#  0.9983347
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","prUd.5,e.6"]#  1.1000067
-@test value(U) ≈ two_by_two_PriceinDemand["U","prUd.5,e.6"]#  1.0005255
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","prUd.5,e.6"]#  1.0021944
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","prUd.5,e.6"]#  0.9960224
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","prUd.5,e.6"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","prUd.5,e.6"]#  0.9479953
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","prUd.5,e.6"]#  1.0361902
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","prUd.5,e.6"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","prUd.5,e.6"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","prUd.5,e.6"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","prUd.5,e.6"]#  31.7151726
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","prUd.5,e.6"]#  48.3595788
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","prUd.5,e.6"]#  25.2158839
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","prUd.5,e.6"]#  28.837054
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","prUd.5,e.6"]#  79.8248298
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","prUd.5,e.6"]#  44.1757122
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","prUd.5,e.6"]#  139.2061339
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","prUd.5,e.6"]#  124.0651604
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","prUd.5,e.6"]#  15.2014384
+    set_value!(endow,1.1*value(endow))
+    # # set_value!(RA,172.2046917)
+    # # set_fixed!(RA, true)
 
-set_value!(esub_ra, 0.0)
-solve!(m)
-# prUd.5,e.0
-@test value(X) ≈ two_by_two_PriceinDemand["X","prUd.5,e.0"]#  1.036716
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","prUd.5,e.0"]#  1.0427805
-@test value(U) ≈ two_by_two_PriceinDemand["U","prUd.5,e.0"]#  1.0391551
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","prUd.5,e.0"]#  1.0023527
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","prUd.5,e.0"]#  0.9957365
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","prUd.5,e.0"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","prUd.5,e.0"]#  0.9443549
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","prUd.5,e.0"]#  1.0388474
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","prUd.5,e.0"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","prUd.5,e.0"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","prUd.5,e.0"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","prUd.5,e.0"]#  31.8424569
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","prUd.5,e.0"]#  48.2435008
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","prUd.5,e.0"]#  25.3058198
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","prUd.5,e.0"]#  28.7550362
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","prUd.5,e.0"]#  79.8122251
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","prUd.5,e.0"]#  44.1883978
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","prUd.5,e.0"]#  139.2024749
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","prUd.5,e.0"]#  128.8552287
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","prUd.5,e.0"]#  10.3915507
 
-set_value!(esub_ra, 0.6)
-set_value!(itax, 0.1)
-solve!(m)
-# Itax=0.1
-@test value(X) ≈ two_by_two_PriceinDemand["X","Itax=0.1"]#  0.9824871
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","Itax=0.1"]#  1.1229317
-@test value(U) ≈ two_by_two_PriceinDemand["U","Itax=0.1"]#  0.9984376
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","Itax=0.1"]#  1.0162348
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","Itax=0.1"]#  0.9711438
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","Itax=0.1"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","Itax=0.1"]#  0.8990369
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","Itax=0.1"]#  1.0329716
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","Itax=0.1"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","Itax=0.1"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","Itax=0.1"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","Itax=0.1"]#  30.8279824
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","Itax=0.1"]#  49.1898724
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","Itax=0.1"]#  25.9249104
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","Itax=0.1"]#  28.2043721
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","Itax=0.1"]#  78.7219666
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","Itax=0.1"]#  45.3073994
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","Itax=0.1"]#  138.7635276
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","Itax=0.1"]#  123.8062579
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","Itax=0.1"]#  15.4017044
+#=
 
-set_value!(otax, 0.1)
-solve!(m)
-# Otax=0.1
-@test value(X) ≈ two_by_two_PriceinDemand["X","Otax=0.1"]#  0.9404866
-@test value(Y) ≈ two_by_two_PriceinDemand["Y","Otax=0.1"]#  1.1855075
-@test value(U) ≈ two_by_two_PriceinDemand["U","Otax=0.1"]#  0.9919353
-@test value(PX) ≈ two_by_two_PriceinDemand["PX","Otax=0.1"]#  1.0547043
-@test value(PY) ≈ two_by_two_PriceinDemand["PY","Otax=0.1"]#  0.9077037
-@test value(PU) ≈ two_by_two_PriceinDemand["PU","Otax=0.1"]#  1
-@test value(PL) ≈ two_by_two_PriceinDemand["PL","Otax=0.1"]#  0.8446743
-@test value(PK) ≈ two_by_two_PriceinDemand["PK","Otax=0.1"]#  0.9614972
-@test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","Otax=0.1"]#  80
-@test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","Otax=0.1"]#  54
-@test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","Otax=0.1"]#  124
-@test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","Otax=0.1"]#  30.6487342
-@test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","Otax=0.1"]#  49.3622823
-@test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","Otax=0.1"]#  25.7908765
-@test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","Otax=0.1"]#  28.3215728
-@test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","Otax=0.1"]#  75.8506412
-@test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","Otax=0.1"]#  48.4739656
-@test value(RA) ≈ two_by_two_PriceinDemand["RA","Otax=0.1"]#  137.4636582
-@test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","Otax=0.1"]#  122.9999725
-@test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","Otax=0.1"]#  15.9343683
+    # # algebraic_version(m)
+    solve!(m)
 
+    # RA=157
+    @test value(X) ≈ two_by_two_PriceinDemand["X","RA=157"]#  1.0363877
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","RA=157"]#  1.0432701
+    @test value(U) ≈ two_by_two_PriceinDemand["U","RA=157"]#  1.0388246
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","RA=157"]#  1.0023514
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","RA=157"]#  0.9957389
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","RA=157"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","RA=157"]#  0.944386
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","RA=157"]#  1.0388246
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","RA=157"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","RA=157"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","RA=157"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","RA=157"]#  31.8413654
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","RA=157"]#  48.2444931
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","RA=157"]#  25.3050487
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","RA=157"]#  28.7557372
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","RA=157"]#  79.812333
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","RA=157"]#  44.1882892
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","RA=157"]#  139.2025004
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","RA=157"]#  128.8142541
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","RA=157"]#  10.4327007
+
+    set_value!(esub_ra, 0.6)
+    solve!(m)
+    # eRA=.6
+    @test value(X) ≈ two_by_two_PriceinDemand["X","eRA=.6"]#  1.0365191
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","eRA=.6"]#  1.0430741
+    @test value(U) ≈ two_by_two_PriceinDemand["U","eRA=.6"]#  1.0389569
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","eRA=.6"]#  1.0023519
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","eRA=.6"]#  0.995738
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","eRA=.6"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","eRA=.6"]#  0.9443736
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","eRA=.6"]#  1.0388337
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","eRA=.6"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","eRA=.6"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","eRA=.6"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","eRA=.6"]#  31.8418024
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","eRA=.6"]#  48.2440959
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","eRA=.6"]#  25.3053574
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","eRA=.6"]#  28.7554566
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","eRA=.6"]#  79.8122898
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","eRA=.6"]#  44.1883326
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","eRA=.6"]#  139.2024902
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","eRA=.6"]#  128.8306562
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","eRA=.6"]#  10.4162285
+
+    set_value!(pr_Ud, 3.)
+    solve!(m)
+    # pr_Ud=3
+    @test value(X) ≈ two_by_two_PriceinDemand["X","pr_Ud=3"]#  1.075007
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","pr_Ud=3"]#  0.9856634
+    @test value(U) ≈ two_by_two_PriceinDemand["U","pr_Ud=3"]#  1.0777062
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","pr_Ud=3"]#  1.0025108
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","pr_Ud=3"]#  0.9954509
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","pr_Ud=3"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","pr_Ud=3"]#  0.9407323
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","pr_Ud=3"]#  1.0415087
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","pr_Ud=3"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","pr_Ud=3"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","pr_Ud=3"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","pr_Ud=3"]#  31.9701227
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","pr_Ud=3"]#  48.1278184
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","pr_Ud=3"]#  25.395985
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","pr_Ud=3"]#  28.6733343
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","pr_Ud=3"]#  79.7996352
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","pr_Ud=3"]#  44.2010741
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","pr_Ud=3"]#  139.2001931
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","pr_Ud=3"]#  133.6355722
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","pr_Ud=3"]#  5.5900505
+
+    set_value!(esub_ra, .5)
+    set_value!(pr_Ud,  2.)
+    solve!(m)
+    # prU2,eRA.5
+    @test value(X) ≈ two_by_two_PriceinDemand["X","prU2,eRA.5"]#  1.0595609
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","prU2,eRA.5"]#  1.0087068
+    @test value(U) ≈ two_by_two_PriceinDemand["U","prU2,eRA.5"]#  1.0621537
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","prU2,eRA.5"]#  1.002447
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","prU2,eRA.5"]#  0.9955662
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","prU2,eRA.5"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","prU2,eRA.5"]#  0.9421925
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","prU2,eRA.5"]#  1.0404339
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","prU2,eRA.5"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","prU2,eRA.5"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","prU2,eRA.5"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","prU2,eRA.5"]#  31.9185419
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","prU2,eRA.5"]#  48.1744684
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","prU2,eRA.5"]#  25.3595604
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","prU2,eRA.5"]#  28.706277
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","prU2,eRA.5"]#  79.8047156
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","prU2,eRA.5"]#  44.1959582
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","prU2,eRA.5"]#  139.2009488
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","prU2,eRA.5"]#  131.7070569
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","prU2,eRA.5"]#  7.5272667
+
+    set_value!(pr_Ud, 0.5)
+    set_value!(esub_ra, 0.6)
+    solve!(m)
+    # prUd.5,e.6
+    @test value(X) ≈ two_by_two_PriceinDemand["X","prUd.5,e.6"]#  0.9983347
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","prUd.5,e.6"]#  1.1000067
+    @test value(U) ≈ two_by_two_PriceinDemand["U","prUd.5,e.6"]#  1.0005255
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","prUd.5,e.6"]#  1.0021944
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","prUd.5,e.6"]#  0.9960224
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","prUd.5,e.6"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","prUd.5,e.6"]#  0.9479953
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","prUd.5,e.6"]#  1.0361902
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","prUd.5,e.6"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","prUd.5,e.6"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","prUd.5,e.6"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","prUd.5,e.6"]#  31.7151726
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","prUd.5,e.6"]#  48.3595788
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","prUd.5,e.6"]#  25.2158839
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","prUd.5,e.6"]#  28.837054
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","prUd.5,e.6"]#  79.8248298
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","prUd.5,e.6"]#  44.1757122
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","prUd.5,e.6"]#  139.2061339
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","prUd.5,e.6"]#  124.0651604
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","prUd.5,e.6"]#  15.2014384
+
+    set_value!(esub_ra, 0.0)
+    solve!(m)
+    # prUd.5,e.0
+    @test value(X) ≈ two_by_two_PriceinDemand["X","prUd.5,e.0"]#  1.036716
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","prUd.5,e.0"]#  1.0427805
+    @test value(U) ≈ two_by_two_PriceinDemand["U","prUd.5,e.0"]#  1.0391551
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","prUd.5,e.0"]#  1.0023527
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","prUd.5,e.0"]#  0.9957365
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","prUd.5,e.0"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","prUd.5,e.0"]#  0.9443549
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","prUd.5,e.0"]#  1.0388474
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","prUd.5,e.0"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","prUd.5,e.0"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","prUd.5,e.0"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","prUd.5,e.0"]#  31.8424569
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","prUd.5,e.0"]#  48.2435008
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","prUd.5,e.0"]#  25.3058198
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","prUd.5,e.0"]#  28.7550362
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","prUd.5,e.0"]#  79.8122251
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","prUd.5,e.0"]#  44.1883978
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","prUd.5,e.0"]#  139.2024749
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","prUd.5,e.0"]#  128.8552287
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","prUd.5,e.0"]#  10.3915507
+
+    set_value!(esub_ra, 0.6)
+    set_value!(itax, 0.1)
+    solve!(m)
+    # Itax=0.1
+    @test value(X) ≈ two_by_two_PriceinDemand["X","Itax=0.1"]#  0.9824871
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","Itax=0.1"]#  1.1229317
+    @test value(U) ≈ two_by_two_PriceinDemand["U","Itax=0.1"]#  0.9984376
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","Itax=0.1"]#  1.0162348
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","Itax=0.1"]#  0.9711438
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","Itax=0.1"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","Itax=0.1"]#  0.8990369
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","Itax=0.1"]#  1.0329716
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","Itax=0.1"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","Itax=0.1"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","Itax=0.1"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","Itax=0.1"]#  30.8279824
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","Itax=0.1"]#  49.1898724
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","Itax=0.1"]#  25.9249104
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","Itax=0.1"]#  28.2043721
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","Itax=0.1"]#  78.7219666
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","Itax=0.1"]#  45.3073994
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","Itax=0.1"]#  138.7635276
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","Itax=0.1"]#  123.8062579
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","Itax=0.1"]#  15.4017044
+
+    set_value!(otax, 0.1)
+    solve!(m)
+    # Otax=0.1
+    @test value(X) ≈ two_by_two_PriceinDemand["X","Otax=0.1"]#  0.9404866
+    @test value(Y) ≈ two_by_two_PriceinDemand["Y","Otax=0.1"]#  1.1855075
+    @test value(U) ≈ two_by_two_PriceinDemand["U","Otax=0.1"]#  0.9919353
+    @test value(PX) ≈ two_by_two_PriceinDemand["PX","Otax=0.1"]#  1.0547043
+    @test value(PY) ≈ two_by_two_PriceinDemand["PY","Otax=0.1"]#  0.9077037
+    @test value(PU) ≈ two_by_two_PriceinDemand["PU","Otax=0.1"]#  1
+    @test value(PL) ≈ two_by_two_PriceinDemand["PL","Otax=0.1"]#  0.8446743
+    @test value(PK) ≈ two_by_two_PriceinDemand["PK","Otax=0.1"]#  0.9614972
+    @test value(compensated_demand(X, PX, :t)) ≈ -two_by_two_PriceinDemand["SX","Otax=0.1"]#  80
+    @test value(compensated_demand(Y, PY, :t)) ≈ -two_by_two_PriceinDemand["SY","Otax=0.1"]#  54
+    @test value(compensated_demand(U, PU, :t)) ≈ -two_by_two_PriceinDemand["SU","Otax=0.1"]#  124
+    @test value(compensated_demand(X, PL)) ≈ two_by_two_PriceinDemand["DXL","Otax=0.1"]#  30.6487342
+    @test value(compensated_demand(X, PK)) ≈ two_by_two_PriceinDemand["DXK","Otax=0.1"]#  49.3622823
+    @test value(compensated_demand(Y, PL)) ≈ two_by_two_PriceinDemand["DYL","Otax=0.1"]#  25.7908765
+    @test value(compensated_demand(Y, PK)) ≈ two_by_two_PriceinDemand["DYK","Otax=0.1"]#  28.3215728
+    @test value(compensated_demand(U, PX)) ≈ two_by_two_PriceinDemand["DUX","Otax=0.1"]#  75.8506412
+    @test value(compensated_demand(U, PY)) ≈ two_by_two_PriceinDemand["DUY","Otax=0.1"]#  48.4739656
+    @test value(RA) ≈ two_by_two_PriceinDemand["RA","Otax=0.1"]#  137.4636582
+    @test value(demand(RA, PU)) ≈ two_by_two_PriceinDemand["DU","Otax=0.1"]#  122.9999725
+    @test value(demand(RA, PY)) ≈ two_by_two_PriceinDemand["DY","Otax=0.1"]#  15.9343683
+
+    =#
 end
-=#

--- a/test/test_twobytwo_indexed.jl
+++ b/test/test_twobytwo_indexed.jl
@@ -581,176 +581,209 @@ end
 end
 
 
-#=
+
 
 @testset "TWOBYTWO (indexed w non-1 Demand prices)" begin 
     using XLSX, MPSGE_MP.JuMP.Containers
     import JuMP
   
     m = MPSGEModel()
-        goods = [:x, :y]
-        factors = [:l, :k]
-        consumers = [:ra]
-        factor = DenseAxisArray(Float64[50 50; 20 30], goods, factors)
-        supply = DenseAxisArray(Float64[100, 50], goods)
-        cons   = DenseAxisArray(Float64[75, 75], factors)
-        pricepu = add!(m, Parameter(:pricepu, indices=(factors,), value=[1.,1]))
-        endow    = add!(m, Parameter(:endow, indices=(factors,), value=[1,1.0])) 
-        
-        Y = add!(m, Sector(:Y, indices=(goods,)))
-        U = add!(m, Sector(:U))
-        PC = add!(m, Commodity(:PC, indices=(goods,)))
-        PU = add!(m, Commodity(:PU, indices=(factors,)))
-        PF = add!(m, Commodity(:PF, indices=(factors,)))
-        C = add!(m, Consumer(:C, indices=(consumers,), benchmark=150.))
+    goods = [:x, :y]
+    factors = [:l, :k]
+    consumers = [:ra]
+    factor = DenseAxisArray(Float64[50 50; 20 30], goods, factors)
+    supply = DenseAxisArray(Float64[100, 50], goods)
+    cons   = DenseAxisArray(Float64[75, 75], factors)
+    raw_endow = DenseAxisArray([70,80], factors)
+    raw_pricepu = DenseAxisArray([1, 1], factors)
     
-        for i in goods
-            @production(m, Y[i], 0, 1, [Output(PC[i], supply[i])], [Input(PF[:l], factor[i,:l]), Input(PF[:k], factor[i,:k])])
-        end
-            add!(m, Production(U, 0., 1, [Output(PU[f], cons[f]) for f in factors], [Input(PC[i], supply[i]) for i in goods]))
-            @demand(m, C[:ra], 1., [Demand(PU[f], cons[f], :($(pricepu[f])*1.)) for f in factors], [Endowment(PF[:l], :(70 * $(endow[:l]))), Endowment(PF[:k], :(80. * $(endow[:k])))])
+    @parameters(m, begin
+        endow, raw_endow, (index = [factors],)
+        pricepu, raw_pricepu, (index = [factors],)
+    end)
 
-solve!(m, cumulative_iteration_limit=0)
+    @sectors(m, begin
+        Y, (index = [goods],)
+        U
+    end)
 
-gams_results = XLSX.readxlsx(joinpath(@__DIR__, "MPSGEresults.xlsx"))
-a_table = gams_results["TwoxTwo_DemandIndPrice_Nest"][:]                                                                                # Generated from TowbyTwo_Indexed_wDemand-non-1price_nest.gms
-TwoxTwo_DemandIndPrice_Nest = DenseAxisArray(a_table[2:end,2:end],string.(a_table[2:end,1],".",a_table[2:end,2]),a_table[1,2:end])
+    @commodities(m, begin
+        PC, (index = [goods],)
+        PU, (index = [factors],)
+        PF, (index = [factors],)
+    end)
 
-# benchmark
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","benchmark"]#  50
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","benchmark"]#  50
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","benchmark"]#  1
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","benchmark"]#  1
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","benchmark"]#  20
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","benchmark"]#  30
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","benchmark"]#  1
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","benchmark"]#  150
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","benchmark"]#  1
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","benchmark"]#  1
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","benchmark"]#  1
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","benchmark"]#  1
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","benchmark"]#  1
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","benchmark"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","benchmark"]#  100
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","benchmark"]#  50
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","benchmark"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","benchmark"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","benchmark"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","benchmark"]#  50
-@test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","benchmark"]#  75
-@test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","benchmark"]#  75
+    @consumer(m, C, index = [consumers])
 
-set_value!(endow[:l], get_value(endow[:l])*1.1)
-set_value(C[:ra], 157.)
-fix(C[:ra], 1)
-solve!(m)
-# RA=157
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","RA=157"]#  52.4404424
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","RA=157"]#  47.6731295
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","RA=157"]#  1.0488088
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","RA=157"]#  1.0388601
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","RA=157"]#  21.1770571
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","RA=157"]#  28.8778051
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","RA=157"]#  1.0454821
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","RA=157"]#  157
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","RA=157"]#  0.9979575
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","RA=157"]#  1.0075145
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","RA=157"]#  0.9515152
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","RA=157"]#  1.0466667
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","RA=157"]#  1.0011331
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","RA=157"]#  1.0011331
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","RA=157"]#  100.3182058
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","RA=157"]#  49.6833066
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","RA=157"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","RA=157"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","RA=157"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","RA=157"]#  50
-@test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","RA=157"]#  78.4111548
-@test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","RA=157"]#  78.4111548
+    for i in goods
+        @production(m, Y[i], 
+            ScalarNest(:t; elasticity = 0, children = [
+                ScalarOutput(PC[i], supply[i])
+            ]),
+            ScalarNest(:s; elasticity = 1, children = [
+                ScalarInput(PF[:l], factor[i,:l]), 
+                ScalarInput(PF[:k], factor[i,:k])
+            ])
+        )      
+    end
 
-unfix(C[:ra])
-fix(PU[:k], 1)
-solve!(m)
-# PC.x=1
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PC.x=1"]#  52.4404424
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PC.x=1"]#  47.6731295
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PC.x=1"]#  1.0488088
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PC.x=1"]#  1.0388601
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PC.x=1"]#  21.1770571
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PC.x=1"]#  28.8778051
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PC.x=1"]#  1.0454821
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PC.x=1"]#  156.8223095
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PC.x=1"]#  0.996828
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PC.x=1"]#  1.0063742
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PC.x=1"]#  0.9504382
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PC.x=1"]#  1.0454821
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PC.x=1"]#  1
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PC.x=1"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PC.x=1"]#  100.3182058
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PC.x=1"]#  49.6833066
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PC.x=1"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PC.x=1"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PC.x=1"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PC.x=1"]#  50
-@test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PC.x=1"]#  78.4111548
-@test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PC.x=1"]#  78.4111548
+    @production(m, U, 
+        ScalarNest(:t; elasticity = 0, children = [
+            ScalarOutput(PU[f], cons[f]) for f∈factors
+        ]),
+        ScalarNest(:s; elasticity = 1, children = [
+            ScalarInput(PC[i], supply[i]) for i∈goods
+        ])
+    )
 
-set_value!(pricepu[:l] , 1.5)
-solve!(m)
-# Pr.l=2
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","Pr.l=1.5"]#  52.4404424
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","Pr.l=1.5"]#  47.6731295
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","Pr.l=1.5"]#  1.0488088
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","Pr.l=1.5"]#  1.0388601
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","Pr.l=1.5"]#  21.1770571
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","Pr.l=1.5"]#  28.8778051
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","Pr.l=1.5"]#  1.0454821
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","Pr.l=1.5"]#  196.0278842
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","Pr.l=1.5"]#  1.246035
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","Pr.l=1.5"]#  1.2579678
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","Pr.l=1.5"]#  1.1880478
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","Pr.l=1.5"]#  1.3068526
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","Pr.l=1.5"]#  1.5
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","Pr.l=1.5"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","Pr.l=1.5"]#  100.3182058
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","Pr.l=1.5"]#  49.6833066
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","Pr.l=1.5"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","Pr.l=1.5"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","Pr.l=1.5"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","Pr.l=1.5"]#  50
-@test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","Pr.l=1.5"]#  78.4111555
-@test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","Pr.l=1.5"]#  78.4111537
+    @demand(m, C[:ra],
+        [ScalarDem(PU[f], cons[f]; reference_price = pricepu[f]) for f∈factors],
+        [ScalarEndowment(PF[f], endow[f]) for f∈factors]
+    )
 
-unfix(PC[:x])
-fix(PF[:l], 1)
-solve!(m)
-#PF.l=1
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PF.l=1"]#  56.5057343
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PF.l=1"]#  44.2432973
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PF.l=1"]#  1.1301147
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PF.l=1"]#  1.1028032
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PF.l=1"]#  23.1620512
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PF.l=1"]#  27.2034033
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PF.l=1"]#  1.1209365
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PF.l=1"]#  179.1727363
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PF.l=1"]#  1.1301147
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PF.l=1"]#  1.1581026
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PF.l=1"]#  1
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PF.l=1"]#  1.2771592
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PF.l=1"]#  1.278736
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PF.l=1"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PF.l=1"]#  100.8187947
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PF.l=1"]#  49.191153
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PF.l=1"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PF.l=1"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PF.l=1"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PF.l=1"]#  50
-@test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PF.l=1"]#  84.0702388
-@test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PF.l=1"]#  71.6690945
+    solve!(m, cumulative_iteration_limit=0)
+
+    gams_results = XLSX.readxlsx(joinpath(@__DIR__, "MPSGEresults.xlsx"))
+    a_table = gams_results["TwoxTwo_DemandIndPrice_Nest"][:]                                                                                # Generated from TowbyTwo_Indexed_wDemand-non-1price_nest.gms
+    TwoxTwo_DemandIndPrice_Nest = DenseAxisArray(a_table[2:end,2:end],string.(a_table[2:end,1],".",a_table[2:end,2]),a_table[1,2:end])
+
+    # benchmark
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","benchmark"]#  50
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","benchmark"]#  50
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","benchmark"]#  1
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","benchmark"]#  1
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","benchmark"]#  20
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","benchmark"]#  30
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","benchmark"]#  1
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","benchmark"]#  150
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","benchmark"]#  1
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","benchmark"]#  1
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","benchmark"]#  1
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","benchmark"]#  1
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","benchmark"]#  1
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","benchmark"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","benchmark"]#  100
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","benchmark"]#  50
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","benchmark"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","benchmark"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","benchmark"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","benchmark"]#  50
+    @test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","benchmark"]#  75
+    @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","benchmark"]#  75
+
+    set_value!(endow[:l], value(endow[:l])*1.1)
+    
+    fix(C[:ra], 157)
+    solve!(m)
+    # RA=157
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","RA=157"]#  52.4404424
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","RA=157"]#  47.6731295
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","RA=157"]#  1.0488088
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","RA=157"]#  1.0388601
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","RA=157"]#  21.1770571
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","RA=157"]#  28.8778051
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","RA=157"]#  1.0454821
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","RA=157"]#  157
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","RA=157"]#  0.9979575
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","RA=157"]#  1.0075145
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","RA=157"]#  0.9515152
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","RA=157"]#  1.0466667
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","RA=157"]#  1.0011331
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","RA=157"]#  1.0011331
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","RA=157"]#  100.3182058
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","RA=157"]#  49.6833066
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","RA=157"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","RA=157"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","RA=157"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","RA=157"]#  50
+    @test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","RA=157"]#  78.4111548
+    @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","RA=157"]#  78.4111548
+
+    unfix(C[:ra])
+    fix(PU[:k], 1)
+    solve!(m)
+    # PC.x=1
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PC.x=1"]#  52.4404424
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PC.x=1"]#  47.6731295
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PC.x=1"]#  1.0488088
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PC.x=1"]#  1.0388601
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PC.x=1"]#  21.1770571
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PC.x=1"]#  28.8778051
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PC.x=1"]#  1.0454821
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PC.x=1"]#  156.8223095
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PC.x=1"]#  0.996828
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PC.x=1"]#  1.0063742
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PC.x=1"]#  0.9504382
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PC.x=1"]#  1.0454821
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PC.x=1"]#  1
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PC.x=1"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PC.x=1"]#  100.3182058
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PC.x=1"]#  49.6833066
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PC.x=1"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PC.x=1"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PC.x=1"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PC.x=1"]#  50
+    @test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PC.x=1"]#  78.4111548
+    @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PC.x=1"]#  78.4111548
+
+    set_value!(pricepu[:l] , 1.5)
+    solve!(m)
+    # Pr.l=2
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","Pr.l=1.5"]#  52.4404424
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","Pr.l=1.5"]#  47.6731295
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","Pr.l=1.5"]#  1.0488088
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","Pr.l=1.5"]#  1.0388601
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","Pr.l=1.5"]#  21.1770571
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","Pr.l=1.5"]#  28.8778051
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","Pr.l=1.5"]#  1.0454821
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","Pr.l=1.5"]#  196.0278842
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","Pr.l=1.5"]#  1.246035
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","Pr.l=1.5"]#  1.2579678
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","Pr.l=1.5"]#  1.1880478
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","Pr.l=1.5"]#  1.3068526
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","Pr.l=1.5"] atol=1e-7 #  1.5
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","Pr.l=1.5"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","Pr.l=1.5"]#  100.3182058
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","Pr.l=1.5"]#  49.6833066
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","Pr.l=1.5"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","Pr.l=1.5"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","Pr.l=1.5"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","Pr.l=1.5"]#  50
+    @test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","Pr.l=1.5"]#  78.4111555
+    @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","Pr.l=1.5"]#  78.4111537
+
+    #unfix(PC[:x])
+    fix(PF[:l], 1)
+    solve!(m)
+    #PF.l=1
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PF.l=1"]#  56.5057343
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PF.l=1"]#  44.2432973
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PF.l=1"]#  1.1301147
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PF.l=1"]#  1.1028032
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PF.l=1"]#  23.1620512
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PF.l=1"]#  27.2034033
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PF.l=1"]#  1.1209365
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PF.l=1"]#  179.1727363
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PF.l=1"]#  1.1301147
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PF.l=1"]#  1.1581026
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PF.l=1"]#  1
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PF.l=1"]#  1.2771592
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PF.l=1"]#  1.278736
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PF.l=1"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PF.l=1"]#  100.8187947
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PF.l=1"]#  49.191153
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PF.l=1"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PF.l=1"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PF.l=1"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PF.l=1"]#  50
+    @test value(demand(C[:ra], PU[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PF.l=1"]#  84.0702388
+    @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PF.l=1"]#  71.6690945
 
 end
 
 
+#=
+## Test excluded. Demand nesting should be replaced with another production block
 
 @testset "TWOBYTWO (indexed w non-1 Demand prices w Nest)" begin 
     using XLSX, MPSGE_MP.JuMP.Containers
@@ -758,175 +791,184 @@ end
 
 
     m = MPSGEModel()
-        goods = [:x, :y]
-        factors = [:l, :k]
-        consumers = [:ra]
-        factor = DenseAxisArray(Float64[50 50; 20 30], goods, factors)
-        supply = DenseAxisArray(Float64[100, 50], goods)
-        cons   = DenseAxisArray(Float64[75, 75], factors)
-        pricepu = add!(m, Parameter(:pricepu, indices=(factors,), value=[1.,1]))
-        endow    = add!(m, Parameter(:endow, indices=(factors,), value=[1,1.0])) 
-        
-        Y = add!(m, Sector(:Y, indices=(goods,)))
-        U = add!(m, Sector(:U))
-        PC = add!(m, Commodity(:PC, indices=(goods,)))
-        PU = add!(m, Commodity(:PU, indices=(factors,)))
-        PF = add!(m, Commodity(:PF, indices=(factors,)))
-        C = add!(m, Consumer(:C, indices=(consumers,), benchmark=150.))
+    goods = [:x, :y]
+    factors = [:l, :k]
+    consumers = [:ra]
+    factor = DenseAxisArray(Float64[50 50; 20 30], goods, factors)
+    supply = DenseAxisArray(Float64[100, 50], goods)
+    cons   = DenseAxisArray(Float64[75, 75], factors)
+
+    raw_pricepci = DenseAxisArray([1,1], goods)
+    raw_endow = DenseAxisArray([70,80], factors)
     
-        for i in goods
-            @production(m, Y[i], 0, 1, [Output(PC[i], supply[i])], [Input(PF[:l], factor[i,:l]), Input(PF[:k], factor[i,:k])])
-        end
-            add!(m, Production(U, 0., 1, [Output(PU[f], cons[f]) for f in factors], [Input(PC[i], supply[i]) for i in goods]))
-            # @demand(m, C[:ra], 1., [Demand(PU[f], cons[f], :($(pricepu[f])*1.)) for f in factors], [Endowment(PF[:l], :(70 * $(endow[:l]))), Endowment(PF[:k], :(80. * $(endow[:k])))])
+    @parameters(m, begin
+        endow, raw_endow, (index = [factors],)
+        pricepci, raw_pricepci, (index = [goods],)
+    end)
+    
 
-            add!(m,DemandFunction(C[:ra], 1., [Demand(Nest(:CU, 1., 150.,
-            [
-                Input(PU[f], cons[f],  price=:($(pricepu[f])*1.)) for f in factors
-            ]
-            ),150. )],
-                # PU[f], cons[f], :($(pricepu[f])*1.)) for f in factors], 
-            [Endowment(PF[:l], :(70 * $(endow[:l]))), Endowment(PF[:k], :(80. * $(endow[:k])))]))
+    pricepu = add!(m, Parameter(:pricepu, indices=(factors,), value=[1.,1]))
+    endow    = add!(m, Parameter(:endow, indices=(factors,), value=[1,1.0])) 
+    
+    Y = add!(m, Sector(:Y, indices=(goods,)))
+    U = add!(m, Sector(:U))
+    PC = add!(m, Commodity(:PC, indices=(goods,)))
+    PU = add!(m, Commodity(:PU, indices=(factors,)))
+    PF = add!(m, Commodity(:PF, indices=(factors,)))
+    C = add!(m, Consumer(:C, indices=(consumers,), benchmark=150.))
 
-solve!(m, cumulative_iteration_limit=0)
+    for i in goods
+        @production(m, Y[i], 0, 1, [Output(PC[i], supply[i])], [Input(PF[:l], factor[i,:l]), Input(PF[:k], factor[i,:k])])
+    end
+        add!(m, Production(U, 0., 1, [Output(PU[f], cons[f]) for f in factors], [Input(PC[i], supply[i]) for i in goods]))
+        # @demand(m, C[:ra], 1., [Demand(PU[f], cons[f], :($(pricepu[f])*1.)) for f in factors], [Endowment(PF[:l], :(70 * $(endow[:l]))), Endowment(PF[:k], :(80. * $(endow[:k])))])
 
-gams_results = XLSX.readxlsx(joinpath(@__DIR__, "MPSGEresults.xlsx"))
-a_table = gams_results["TwoxTwo_DemandIndPrice_Nest"][:]                                                                                # Generated from TowbyTwo_Indexed_wDemand-non-1price_nest.gms
-TwoxTwo_DemandIndPrice_Nest = DenseAxisArray(a_table[2:end,2:end],string.(a_table[2:end,1],".",a_table[2:end,2]),a_table[1,2:end])
+        add!(m,DemandFunction(C[:ra], 1., [Demand(Nest(:CU, 1., 150.,
+        [
+            Input(PU[f], cons[f],  price=:($(pricepu[f])*1.)) for f in factors
+        ]
+        ),150. )],
+            # PU[f], cons[f], :($(pricepu[f])*1.)) for f in factors], 
+        [Endowment(PF[:l], :(70 * $(endow[:l]))), Endowment(PF[:k], :(80. * $(endow[:k])))]))
 
-# benchmark
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","benchmark"]#  50
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","benchmark"]#  50
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","benchmark"]#  1
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","benchmark"]#  1
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","benchmark"]#  20
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","benchmark"]#  30
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","benchmark"]#  1
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","benchmark"]#  150
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","benchmark"]#  1
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","benchmark"]#  1
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","benchmark"]#  1
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","benchmark"]#  1
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","benchmark"]#  1
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","benchmark"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","benchmark"]#  100
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","benchmark"]#  50
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","benchmark"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","benchmark"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","benchmark"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","benchmark"]#  50
-#@test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","benchmark"] + TwoxTwo_DemandIndPrice_Nest["FDRA.K","benchmark"] # 75 + 75
-# @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","benchmark"]#  75
+    solve!(m, cumulative_iteration_limit=0)
 
-set_value!(endow[:l], get_value(endow[:l])*1.1)
-set_value(C[:ra], 157.)
-fix(C[:ra], 1)
-solve!(m)
-# RA=157
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","RA=157"]#  52.4404424
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","RA=157"]#  47.6731295
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","RA=157"]#  1.0488088
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","RA=157"]#  1.0388601
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","RA=157"]#  21.1770571
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","RA=157"]#  28.8778051
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","RA=157"]#  1.0454821
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","RA=157"]#  157
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","RA=157"]#  0.9979575
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","RA=157"]#  1.0075145
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","RA=157"]#  0.9515152
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","RA=157"]#  1.0466667
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","RA=157"]#  1.0011331
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","RA=157"]#  1.0011331
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","RA=157"]#  100.3182058
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","RA=157"]#  49.6833066
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","RA=157"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","RA=157"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","RA=157"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","RA=157"]#  50
-# @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","RA=157"] + TwoxTwo_DemandIndPrice_Nest["FDRA.K","RA=157"] # 78.4111548 + 78.4111548
-# @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","RA=157"]#  78.4111548
+    gams_results = XLSX.readxlsx(joinpath(@__DIR__, "MPSGEresults.xlsx"))
+    a_table = gams_results["TwoxTwo_DemandIndPrice_Nest"][:]                                                                                # Generated from TowbyTwo_Indexed_wDemand-non-1price_nest.gms
+    TwoxTwo_DemandIndPrice_Nest = DenseAxisArray(a_table[2:end,2:end],string.(a_table[2:end,1],".",a_table[2:end,2]),a_table[1,2:end])
 
-unfix(C[:ra])
-fix(PU[:k], 1)
-solve!(m)
-# PC.x=1
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PC.x=1"]#  52.4404424
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PC.x=1"]#  47.6731295
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PC.x=1"]#  1.0488088
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PC.x=1"]#  1.0388601
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PC.x=1"]#  21.1770571
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PC.x=1"]#  28.8778051
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PC.x=1"]#  1.0454821
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PC.x=1"]#  156.8223095
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PC.x=1"]#  0.996828
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PC.x=1"]#  1.0063742
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PC.x=1"]#  0.9504382
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PC.x=1"]#  1.0454821
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PC.x=1"]#  1
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PC.x=1"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PC.x=1"]#  100.3182058
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PC.x=1"]#  49.6833066
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PC.x=1"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PC.x=1"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PC.x=1"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PC.x=1"]#  50
-# @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PC.x=1"] + TwoxTwo_DemandIndPrice_Nest["FDRA.K","PC.x=1"] # 78.4111548 + 78.4111548
-# @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PC.x=1"]#  78.4111548
+    # benchmark
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","benchmark"]#  50
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","benchmark"]#  50
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","benchmark"]#  1
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","benchmark"]#  1
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","benchmark"]#  20
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","benchmark"]#  30
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","benchmark"]#  1
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","benchmark"]#  150
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","benchmark"]#  1
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","benchmark"]#  1
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","benchmark"]#  1
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","benchmark"]#  1
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","benchmark"]#  1
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","benchmark"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","benchmark"]#  100
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","benchmark"]#  50
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","benchmark"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","benchmark"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","benchmark"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","benchmark"]#  50
+    #@test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","benchmark"] + TwoxTwo_DemandIndPrice_Nest["FDRA.K","benchmark"] # 75 + 75
+    # @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","benchmark"]#  75
 
-set_value(pricepu[:l] , 1.5)
-solve!(m)
-# Pr.l=2
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","Pr.l=1.5"]#  52.4404424
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","Pr.l=1.5"]#  47.6731295
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","Pr.l=1.5"]#  1.0488088
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","Pr.l=1.5"]#  1.0388601
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","Pr.l=1.5"]#  21.1770571
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","Pr.l=1.5"]#  28.8778051
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","Pr.l=1.5"]#  1.0454821
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","Pr.l=1.5"]#  196.0278842
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","Pr.l=1.5"]#  1.246035
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","Pr.l=1.5"]#  1.2579678
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","Pr.l=1.5"]#  1.1880478
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","Pr.l=1.5"]#  1.3068526
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","Pr.l=1.5"] atol= 1e-7 #  1.5 
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","Pr.l=1.5"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","Pr.l=1.5"]#  100.3182058
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","Pr.l=1.5"]#  49.6833066
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","Pr.l=1.5"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","Pr.l=1.5"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","Pr.l=1.5"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","Pr.l=1.5"]#  50
-# @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","Pr.l=1.5"]+TwoxTwo_DemandIndPrice_Nest["FDRA.K","Pr.l=1.5"]#  78.4111555 + 78.4111555
-# @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","Pr.l=1.5"]#  78.4111537
+    set_value!(endow[:l], get_value(endow[:l])*1.1)
+    set_value(C[:ra], 157.)
+    fix(C[:ra], 1)
+    solve!(m)
+    # RA=157
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","RA=157"]#  52.4404424
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","RA=157"]#  47.6731295
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","RA=157"]#  1.0488088
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","RA=157"]#  1.0388601
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","RA=157"]#  21.1770571
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","RA=157"]#  28.8778051
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","RA=157"]#  1.0454821
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","RA=157"]#  157
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","RA=157"]#  0.9979575
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","RA=157"]#  1.0075145
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","RA=157"]#  0.9515152
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","RA=157"]#  1.0466667
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","RA=157"]#  1.0011331
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","RA=157"]#  1.0011331
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","RA=157"]#  100.3182058
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","RA=157"]#  49.6833066
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","RA=157"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","RA=157"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","RA=157"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","RA=157"]#  50
+    # @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","RA=157"] + TwoxTwo_DemandIndPrice_Nest["FDRA.K","RA=157"] # 78.4111548 + 78.4111548
+    # @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","RA=157"]#  78.4111548
 
-unfix(PC[:x])
-fix(PF[:l], 1)
-solve!(m)
-# PF.l=1
-@test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PF.l=1"]#  56.5057343
-@test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PF.l=1"]#  44.2432973
-@test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PF.l=1"]#  1.1301147
-@test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PF.l=1"]#  1.1028032
-@test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PF.l=1"]#  23.1620512
-@test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PF.l=1"]#  27.2034033
-@test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PF.l=1"]#  1.1209365
-@test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PF.l=1"]#  179.1727363
-@test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PF.l=1"]#  1.1301147
-@test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PF.l=1"]#  1.1581026
-@test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PF.l=1"]#  1
-@test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PF.l=1"]#  1.2771592
-@test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PF.l=1"]#  1.278736
-@test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PF.l=1"]#  1
-@test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PF.l=1"]#  100.8187947
-@test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PF.l=1"]#  49.191153
-@test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PF.l=1"]#  75
-@test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PF.l=1"]#  75
-@test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PF.l=1"]#  100
-@test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PF.l=1"]#  50
-# For the counterfacturals where there two nested final demands are equal, summing matches our results, but for this they are different and summing the two doesn't match
-# @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PF.l=1"]+TwoxTwo_DemandIndPrice_Nest["FDRA.K","PF.l=1"]#  84.0702388 +  71.6690945
-# @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PF.l=1"]#  71.6690945
+    unfix(C[:ra])
+    fix(PU[:k], 1)
+    solve!(m)
+    # PC.x=1
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PC.x=1"]#  52.4404424
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PC.x=1"]#  47.6731295
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PC.x=1"]#  1.0488088
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PC.x=1"]#  1.0388601
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PC.x=1"]#  21.1770571
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PC.x=1"]#  28.8778051
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PC.x=1"]#  1.0454821
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PC.x=1"]#  156.8223095
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PC.x=1"]#  0.996828
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PC.x=1"]#  1.0063742
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PC.x=1"]#  0.9504382
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PC.x=1"]#  1.0454821
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PC.x=1"]#  1
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PC.x=1"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PC.x=1"]#  100.3182058
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PC.x=1"]#  49.6833066
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PC.x=1"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PC.x=1"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PC.x=1"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PC.x=1"]#  50
+    # @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PC.x=1"] + TwoxTwo_DemandIndPrice_Nest["FDRA.K","PC.x=1"] # 78.4111548 + 78.4111548
+    # @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PC.x=1"]#  78.4111548
+
+    set_value(pricepu[:l] , 1.5)
+    solve!(m)
+    # Pr.l=2
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","Pr.l=1.5"]#  52.4404424
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","Pr.l=1.5"]#  47.6731295
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","Pr.l=1.5"]#  1.0488088
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","Pr.l=1.5"]#  1.0388601
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","Pr.l=1.5"]#  21.1770571
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","Pr.l=1.5"]#  28.8778051
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","Pr.l=1.5"]#  1.0454821
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","Pr.l=1.5"]#  196.0278842
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","Pr.l=1.5"]#  1.246035
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","Pr.l=1.5"]#  1.2579678
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","Pr.l=1.5"]#  1.1880478
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","Pr.l=1.5"]#  1.3068526
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","Pr.l=1.5"] atol= 1e-7 #  1.5 
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","Pr.l=1.5"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","Pr.l=1.5"]#  100.3182058
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","Pr.l=1.5"]#  49.6833066
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","Pr.l=1.5"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","Pr.l=1.5"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","Pr.l=1.5"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","Pr.l=1.5"]#  50
+    # @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","Pr.l=1.5"]+TwoxTwo_DemandIndPrice_Nest["FDRA.K","Pr.l=1.5"]#  78.4111555 + 78.4111555
+    # @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","Pr.l=1.5"]#  78.4111537
+
+    unfix(PC[:x])
+    fix(PF[:l], 1)
+    solve!(m)
+    # PF.l=1
+    @test value(compensated_demand(Y[:x], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["x.L","PF.l=1"]#  56.5057343
+    @test value(compensated_demand(Y[:x], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["x.K","PF.l=1"]#  44.2432973
+    @test value(Y[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["y.x","PF.l=1"]#  1.1301147
+    @test value(Y[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["y.y","PF.l=1"]#  1.1028032
+    @test value(compensated_demand(Y[:y], PF[:l])) ≈ TwoxTwo_DemandIndPrice_Nest["y.L","PF.l=1"]#  23.1620512
+    @test value(compensated_demand(Y[:y], PF[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["y.K","PF.l=1"]#  27.2034033
+    @test value(U) ≈ TwoxTwo_DemandIndPrice_Nest["U._","PF.l=1"]#  1.1209365
+    @test value(C[:ra]) ≈ TwoxTwo_DemandIndPrice_Nest["RA._","PF.l=1"]#  179.1727363
+    @test value(PC[:x]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.x","PF.l=1"]#  1.1301147
+    @test value(PC[:y]) ≈ TwoxTwo_DemandIndPrice_Nest["PC.y","PF.l=1"]#  1.1581026
+    @test value(PF[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.L","PF.l=1"]#  1
+    @test value(PF[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PF.K","PF.l=1"]#  1.2771592
+    @test value(PU[:l]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.L","PF.l=1"]#  1.278736
+    @test value(PU[:k]) ≈ TwoxTwo_DemandIndPrice_Nest["PU.K","PF.l=1"]#  1
+    @test value(compensated_demand(U, PC[:x])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.x","PF.l=1"]#  100.8187947
+    @test value(compensated_demand(U, PC[:y])) ≈ TwoxTwo_DemandIndPrice_Nest["DU.y","PF.l=1"]#  49.191153
+    @test value(compensated_demand(U, PU[:l], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.L","PF.l=1"]#  75
+    @test value(compensated_demand(U, PU[:k], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SU.K","PF.l=1"]#  75
+    @test value(compensated_demand(Y[:x], PC[:x], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.x","PF.l=1"]#  100
+    @test value(compensated_demand(Y[:y], PC[:y], :t)) ≈ -TwoxTwo_DemandIndPrice_Nest["SY.y","PF.l=1"]#  50
+    # For the counterfacturals where there two nested final demands are equal, summing matches our results, but for this they are different and summing the two doesn't match
+    # @test value(m._jump_model[Symbol("PC→CUρC[ra]")]) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.L","PF.l=1"]+TwoxTwo_DemandIndPrice_Nest["FDRA.K","PF.l=1"]#  84.0702388 +  71.6690945
+    # @test value(demand(C[:ra], PU[:k])) ≈ TwoxTwo_DemandIndPrice_Nest["FDRA.K","PF.l=1"]#  71.6690945
 
 end
-
 =#


### PR DESCRIPTION
ScalarDemands can have an associated elasticity and ScalarDems can have a reference price. This adds this functionality. 