### PR TITLE
Expressions

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -35,7 +35,7 @@ function build_nested_compensated_demand!(P::ScalarProduction)
 end
 
 function build_nested_compensated_demand(P::ScalarProduction,T::ScalarNest, sign::Int)
-    if raw_elasticity(T) isa Parameter
+    if !(isa(raw_elasticity(T), Real))
 
         jm = jump_model(model(sector(P)))
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -45,6 +45,13 @@ function Base.show(io::IO,S::MPSGEIndexedVariable) #This could be smarter
     print(io,S.subsectors)
 end
 
+#################
+## Expressions ##
+#################
+function Base.show(io::IO, e::abstractMPSGEExpr)
+    print(io, join(["($a)" for a∈e.args], " $(e.head) "))
+end
+
 ########################
 ## Production/Demands ##
 ########################

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -9,6 +9,8 @@ abstract type MPSGEVariable end
 abstract type MPSGEIndexedVariable <: MPSGEVariable end
 abstract type MPSGEScalarVariable <: MPSGEVariable end
 
+abstract type abstractMPSGEExpr end
+
 abstract type ScalarNetput end
 abstract type IndexedNetput end
 
@@ -195,6 +197,34 @@ end
 set_value!(P::IndexedParameter, value::Number) = set_value!.(P.subsectors,value)
 set_value!(P::IndexedParameter, value::AbstractArray) = set_value!.(P.subsectors,value)
 
+#######################
+## MPSGE Expressions ##
+#######################
+struct MPSGEExpr <: abstractMPSGEExpr
+    head::Symbol
+    args::Vector{Union{Real,ScalarParameter,abstractMPSGEExpr}}
+end
+
+const MPSGEquantity = Union{Real,MPSGE_MP.MPSGEScalarVariable,MPSGEExpr}
+const _MPSGEquantity = Union{MPSGE_MP.MPSGEScalarVariable,MPSGEExpr}
+
+value(x::abstractMPSGEExpr) = value(MPSGE_MP._get_parameter_value(x))
+
+
+Base.:+(x::MPSGEquantity,y::_MPSGEquantity) = MPSGEExpr(:+, [x, y])
+Base.:+(x::_MPSGEquantity,y::Real) = MPSGEExpr(:+, [x, y])
+
+Base.:-(x::MPSGEquantity,y::_MPSGEquantity) = MPSGEExpr(:-, [x, y])
+Base.:-(x::_MPSGEquantity,y::Real) = MPSGEExpr(:-, [x, y])
+
+Base.:*(x::MPSGEquantity,y::_MPSGEquantity) = MPSGEExpr(:*, [x, y])
+Base.:*(x::_MPSGEquantity,y::Real) = MPSGEExpr(:*, [x, y])
+
+Base.:/(x::MPSGEquantity,y::_MPSGEquantity) = MPSGEExpr(:/, [x, y])
+Base.:/(x::_MPSGEquantity,y::Real) = MPSGEExpr(:/, [x, y])
+
+Base.:^(x::MPSGEquantity,y::_MPSGEquantity) = MPSGEExpr(:^, [x, y])
+Base.:^(x::_MPSGEquantity,y::Real) = MPSGEExpr(:^, [x, y])
 
 
 ####################
@@ -214,6 +244,11 @@ function _get_parameter_value(X::ScalarParameter)
         return get_variable(X)
     end
     return value(X)
+end
+
+
+function _get_parameter_value(x::abstractMPSGEExpr)
+    return NonlinearExpr(x.head, _get_parameter_value.(x.args)...)
 end
 
 
@@ -254,27 +289,27 @@ tax(T::Tax) = _get_parameter_value(T.tax)
 
 mutable struct ScalarInput <: ScalarNetput
     commodity::ScalarCommodity
-    quantity::Union{Real,ScalarParameter}
-    reference_price::Union{Real,ScalarParameter}
+    quantity::MPSGEquantity
+    reference_price::MPSGEquantity
     taxes::Vector{Tax}
     parent::Union{AbstractNest,Missing}
     ScalarInput(commodity::ScalarCommodity,
-                         quantity::Union{Real,ScalarParameter};
-                         reference_price::Union{Real,ScalarParameter}=1,
-                         taxes = []
+                quantity::MPSGEquantity;
+                reference_price::MPSGEquantity=1,
+                taxes = []
         ) = new(commodity,quantity,reference_price,taxes,missing)
 end
 
 
 mutable struct ScalarOutput <: ScalarNetput
     commodity::ScalarCommodity
-    quantity::Union{Real,ScalarParameter}
-    reference_price::Union{Real,ScalarParameter}
+    quantity::MPSGEquantity
+    reference_price::MPSGEquantity
     taxes::Vector{Tax}
     parent::Union{AbstractNest,Missing}
     ScalarOutput(commodity::ScalarCommodity,
-                 quantity::Union{Real,ScalarParameter};
-                 reference_price::Union{Real,ScalarParameter}=1,
+                 quantity::MPSGEquantity;
+                 reference_price::MPSGEquantity=1,
                  taxes = []
         ) = new(commodity,quantity,reference_price,taxes,missing)
 end
@@ -282,10 +317,10 @@ end
 
 mutable struct ScalarNest <: AbstractNest
     name::Symbol
-    elasticity::Union{Real,ScalarParameter}
+    elasticity::MPSGEquantity
     children::Vector{Union{ScalarNest,ScalarNetput}}
     parent::Union{ScalarNest,Missing}
-    function ScalarNest(name::Symbol;elasticity::Union{Real,ScalarParameter}=0,children = [])  
+    function ScalarNest(name::Symbol;elasticity::MPSGEquantity=0,children = [])  
         N = new(name,elasticity,children, missing)
         for child in children
             set_parent(child,N)
@@ -327,15 +362,15 @@ taxes(P::Production) = P.taxes
 
 struct ScalarDem
     commodity::ScalarCommodity
-    quantity::Union{Real,Parameter}
-    reference_price::Union{Real,Parameter}
-    ScalarDem(commodity::ScalarCommodity, quantity::Union{Real,Parameter}; reference_price::Union{Real,Parameter} = 1) = new(commodity,quantity,reference_price)
+    quantity::MPSGEquantity
+    reference_price::MPSGEquantity
+    ScalarDem(commodity::ScalarCommodity, quantity::MPSGEquantity; reference_price::MPSGEquantity = 1) = new(commodity,quantity,reference_price)
 end
 
 
 struct ScalarEndowment
     commodity::ScalarCommodity
-    quantity::Union{Real,Parameter}
+    quantity::MPSGEquantity
 end
 
 # Getters
@@ -350,14 +385,14 @@ quantity(C::ScalarEndowment) = _get_parameter_value(C.quantity)
 
 struct ScalarDemand
     consumer::ScalarConsumer
-    elasticity::Union{Real, ScalarParameter}
+    elasticity::MPSGEquantity
     demands::Dict{Commodity,ScalarDem}
     endowments::Dict{Commodity,ScalarEndowment}
     function ScalarDemand(
         consumer::ScalarConsumer,
         demands::Vector{ScalarDem},
         endowments::Vector{ScalarEndowment};
-        elasticity::Union{Real,ScalarParameter} = 1
+        elasticity::MPSGEquantity = 1
         )
             new(consumer,
                 elasticity,

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -205,10 +205,10 @@ struct MPSGEExpr <: abstractMPSGEExpr
     args::Vector{Union{Real,ScalarParameter,abstractMPSGEExpr}}
 end
 
-const MPSGEquantity = Union{Real,MPSGE_MP.MPSGEScalarVariable,MPSGEExpr}
-const _MPSGEquantity = Union{MPSGE_MP.MPSGEScalarVariable,MPSGEExpr}
+const MPSGEquantity = Union{Real,MPSGEScalarVariable,MPSGEExpr}
+const _MPSGEquantity = Union{MPSGEScalarVariable,MPSGEExpr}
 
-value(x::abstractMPSGEExpr) = value(MPSGE_MP._get_parameter_value(x))
+value(x::abstractMPSGEExpr) = value(_get_parameter_value(x))
 
 
 Base.:+(x::MPSGEquantity,y::_MPSGEquantity) = MPSGEExpr(:+, [x, y])

--- a/test/test_Benchmark-Theta.jl
+++ b/test/test_Benchmark-Theta.jl
@@ -4,8 +4,8 @@
 
     m = MPSGEModel()
 
-    @parameter(m, endow, 1*70)
-    @parameter(m, diff, 100)
+    @parameter(m, endow, 1)
+    @parameter(m, diff, 0)
     
     @sector(m, X)
     @sector(m, Y)
@@ -21,7 +21,7 @@
     
     @production(m, X, 
         ScalarNest(:t; elasticity = 0, children = [
-            ScalarOutput(PX,diff)
+            ScalarOutput(PX, 100 + diff)
         ]),
         ScalarNest(:s; elasticity = 1, children = [
             ScalarInput(PL, 50), ScalarInput(PK, 50)
@@ -43,7 +43,7 @@
         ScalarNest(:s; elasticity = 1, children = [ScalarInput(PX, 100), ScalarInput(PY, 50)])
     )
     
-    @demand(m, RA, [ScalarDem(PU, 150)], [ScalarEndowment(PL, endow), ScalarEndowment(PK, 80.)])
+    @demand(m, RA, [ScalarDem(PU, 150)], [ScalarEndowment(PL, endow * 70), ScalarEndowment(PK, 80.)])
     
 
     solve!(m, cumulative_iteration_limit=0)
@@ -65,8 +65,8 @@
     @test value(compensated_demand(U,PX)) ≈  100.
     @test value(compensated_demand(U,PY)) ≈  50.
 
-    set_value!(diff, 100 + 10.)
-    set_value!(endow, 70*1.1)
+    set_value!(diff,  10)
+    set_value!(endow, 1.1)
     fix(RA, 157.0)
     
     solve!(m)
@@ -101,8 +101,8 @@ end
 
     m = MPSGEModel()
 
-    @parameter(m, endow, 1*70)
-    @parameter(m, diff, 50)
+    @parameter(m, endow, 1)
+    @parameter(m, diff, 0)
 
     @sector(m, X)
     @sector(m, Y)
@@ -121,7 +121,7 @@ end
             ScalarOutput(PX,100)
         ]),
         ScalarNest(:s; elasticity = 1, children = [
-            ScalarInput(PL, diff), ScalarInput(PK, 50)
+            ScalarInput(PL, 50 + diff), ScalarInput(PK, 50)
         ])
     )
 
@@ -140,7 +140,7 @@ end
         ScalarNest(:s; elasticity = 1, children = [ScalarInput(PX, 100), ScalarInput(PY, 50)])
     )
 
-    @demand(m, RA, [ScalarDem(PU, 150)], [ScalarEndowment(PL, endow), ScalarEndowment(PK, 80.)])
+    @demand(m, RA, [ScalarDem(PU, 150)], [ScalarEndowment(PL, endow * 70), ScalarEndowment(PK, 80.)])
 
     solve!(m, cumulative_iteration_limit=0)
 
@@ -161,7 +161,7 @@ end
     @test value(compensated_demand(U,PX)) ≈  100.
     @test value(compensated_demand(U,PY)) ≈  50.
 
-    set_value!(diff, 50 + 10.)
+    set_value!(diff, 10.)
     fix(RA, 150)
     solve!(m)
 
@@ -185,7 +185,7 @@ end
     @test value(RA) ≈ 150
     @test value(demand(RA,PU)) ≈ 140.5066 atol=1.0e-4
 
-    set_value!(endow, 70*1.1)
+    set_value!(endow, 1.1)
     fix(RA,157.0)
     
     solve!(m)

--- a/test/test_twobytwo_Price.jl
+++ b/test/test_twobytwo_Price.jl
@@ -1,5 +1,3 @@
-
-#=
 @testset "TWOBYTWO (functional version , with non-1 prices in Inputs)" begin
     using XLSX, MPSGE_MP.JuMP.Containers
     import JuMP
@@ -11,7 +9,7 @@
     m = MPSGEModel()
     # Here parameter values are doubled and input data halved from MPSGE version 
     @parameters(m, begin
-        endow, 1 * 74
+        endow, 1
         esub_x, 1
         esub_y, 1
         esub_u, 1
@@ -69,7 +67,7 @@
     @demand(m, RA, 
         [ScalarDem(PU,164)],
         [
-            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PL, endow * 74), 
             ScalarEndowment(PK, 80)
         ]
     )
@@ -102,7 +100,7 @@
     @test value(demand(RA, PU)) ≈ two_by_two_PriceinInput["DU","benchmark"]#  164
     # @test value(m._jump_model[:]) ≈ two_by_two_PriceinInput["CWI","benchmark"]#  1.09333333
 
-    set_value!(endow,1.1 * 74)
+    set_value!(endow, 1.1)
     solve!(m)
 
     # RA=157
@@ -242,7 +240,7 @@ end
     m = MPSGEModel()
     # Here parameter values are doubled and input data halved from MPSGE version
     @parameters(m, begin
-        endow, 1 * 54
+        endow, 1
         esub_x, 1
         esub_y, 1
         esub_u, 1
@@ -300,7 +298,7 @@ end
     @demand(m, RA, 
         [ScalarDem(PU,154)],
         [
-            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PL, endow * 54), 
             ScalarEndowment(PK, 80)
         ]
     )
@@ -462,8 +460,6 @@ end
 
 
 
-=#
-
 @testset "TWOBYTWO (functional version , with non-1 prices in Demand)" begin
     using XLSX, MPSGE_MP.JuMP.Containers
     import JuMP
@@ -475,7 +471,7 @@ end
     m = MPSGEModel()
 
     @parameters(m, begin
-        endow, 54
+        endow, 1
         esub_x, 1
         esub_y, 1
         esub_u, 1
@@ -539,7 +535,7 @@ end
             ScalarDem(PY, 10)    
         ],
         [
-            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PL, endow * 54), 
             ScalarEndowment(PK, 80)
         ],
         elasticity = esub_ra

--- a/test/test_twobytwo_ces_functional.jl
+++ b/test/test_twobytwo_ces_functional.jl
@@ -5,10 +5,10 @@
     m = MPSGEModel()
     # Here parameter values are doubled and input data halved from MPSGE version       
     @parameters(m, begin
-        inputcoeff, 2 * 25
-        endow, 2 * 35
-        elascoeff, 2 * .3
-        outputmult, 2 * 75
+        inputcoeff, 2
+        endow, 2
+        elascoeff, 2
+        outputmult, 2
     end)
     
     @sectors(m, begin
@@ -32,7 +32,7 @@
             ScalarOutput(PX,100)
         ]),
         ScalarNest(:s; elasticity = .5, children = [
-            ScalarInput(PL, inputcoeff), 
+            ScalarInput(PL, 25 * inputcoeff), 
             ScalarInput(PK, 50)
         ])
     )
@@ -41,7 +41,7 @@
         ScalarNest(:t; elasticity = 0, children = [
             ScalarOutput(PY,50)
         ]),
-        ScalarNest(:s; elasticity = elascoeff, children = [
+        ScalarNest(:s; elasticity = .3 * elascoeff, children = [
             ScalarInput(PL, 20), 
             ScalarInput(PK, 30)
         ])
@@ -49,7 +49,7 @@
 
     @production(m, U, 
         ScalarNest(:t; elasticity = 0, children = [
-            ScalarOutput(PU, outputmult)
+            ScalarOutput(PU, 75 * outputmult)
         ]),
         ScalarNest(:s; elasticity = 1, children = [
             ScalarInput(PX, 100), 
@@ -60,7 +60,7 @@
     @demand(m, RA,
         [ScalarDem(PU,150)],
         [
-            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PL, 35 * endow), 
             ScalarEndowment(PK, 80)
         ]
     )
@@ -89,7 +89,7 @@
     @test value(compensated_demand(U,PY,:s)) ≈ two_by_two_CES["DY.L","benchmark"] # 50.
 
 
-    set_value!(endow, 2.2 * 35)
+    set_value!(endow, 2.2)
     fix(RA, 157)
     
     solve!(m)

--- a/test/test_twobytwo_functional.jl
+++ b/test/test_twobytwo_functional.jl
@@ -5,10 +5,10 @@
     m = MPSGEModel()
     # Here parameter values are doubled and input data halved from MPSGE version       
     @parameters(m, begin
-        inputcoeff, 2 * 25
-        endow, 2 * 35
-        elascoeff, 2 * .5
-        outputmult, 2 * 75
+        inputcoeff, 2
+        endow, 2
+        elascoeff, 2
+        outputmult, 2
     end)
 
     @sectors(m, begin
@@ -32,7 +32,7 @@
             ScalarOutput(PX,100)
         ]),
         ScalarNest(:s; elasticity = 1, children = [
-            ScalarInput(PL, inputcoeff), 
+            ScalarInput(PL, inputcoeff * 25), 
             ScalarInput(PK, 50)
         ])
     )
@@ -41,7 +41,7 @@
         ScalarNest(:t; elasticity = 0, children = [
             ScalarOutput(PY,50)
         ]),
-        ScalarNest(:s; elasticity = elascoeff, children = [
+        ScalarNest(:s; elasticity = elascoeff * .5, children = [
             ScalarInput(PL, 20), 
             ScalarInput(PK, 30)
         ])
@@ -49,7 +49,7 @@
 
     @production(m, U, 
         ScalarNest(:t; elasticity = 0, children = [
-            ScalarOutput(PU, outputmult)
+            ScalarOutput(PU, outputmult * 75)
         ]),
         ScalarNest(:s; elasticity = 1, children = [
             ScalarInput(PX, 100), 
@@ -60,7 +60,7 @@
     @demand(m, RA,
         [ScalarDem(PU,150)],
         [
-            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PL, endow * 35), 
             ScalarEndowment(PK, 80)
         ]
     )
@@ -91,7 +91,7 @@
 
 
     fix(PX, 1)
-    set_value!(endow, 2.2 * 35)
+    set_value!(endow, 2.2)
     solve!(m)
 
     @test value(X) ≈ two_by_two_scalar_results["X.L","PX=1"]#    1.04880885

--- a/test/test_twobytwo_macro.jl
+++ b/test/test_twobytwo_macro.jl
@@ -6,10 +6,10 @@
     # Here again, parameter values are doubled and input data halved from MPSGE version 
     
     @parameters(m, begin
-        inputcoeff, 2 * 25
-        endow, 2 * 35
-        elascoeff, 2 * .5
-        outputmult, 2 * 75
+        inputcoeff, 2
+        endow, 2
+        elascoeff, 2
+        outputmult, 2
     end)
     
     @sector(m, X)
@@ -29,7 +29,7 @@
             ScalarOutput(PX, 100)
         ]), 
         ScalarNest(:s; elasticity = 1, children = [
-            ScalarInput(PL, inputcoeff), 
+            ScalarInput(PL, inputcoeff * 25), 
             ScalarInput(PK, 50)
         ])
     )
@@ -38,7 +38,7 @@
         ScalarNest(:t; elasticity = 0, children = [
             ScalarOutput(PY, 50)
         ]), 
-        ScalarNest(:s; elasticity = elascoeff, children = [
+        ScalarNest(:s; elasticity = elascoeff * .5, children = [
             ScalarInput(PL, 20), 
             ScalarInput(PK, 30)
         ])
@@ -46,7 +46,7 @@
 
     @production(m, U, 
         ScalarNest(:t; elasticity = 0, children = [
-            ScalarOutput(PU, outputmult)
+            ScalarOutput(PU, outputmult * 75)
         ]), 
         ScalarNest(:s; elasticity = 1, children = [
             ScalarInput(PX, 100), 
@@ -57,7 +57,7 @@
     @demand(m, RA, 
         [ScalarDem(PU, 150)], 
         [
-            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PL, endow * 35), 
             ScalarEndowment(PK, 80)
         ]
     )
@@ -87,7 +87,7 @@
     @test value(compensated_demand(U,PY)) ≈ two_by_two_scalar_results["DY.L","benchmark"]#    50.
 
     fix(PX, 1)
-    set_value!(endow, 2.2 *35)
+    set_value!(endow, 2.2)
     solve!(m)
 
     @test value(X) ≈ two_by_two_scalar_results["X.L","PX=1"]#    1.04880885
@@ -136,8 +136,7 @@ end
 
     m = MPSGEModel()
 
-    @parameter(m, diff, 20.0)
-    @parameter(m, diff2, 100.0)
+    @parameter(m, diff, 0.0)
     @parameter(m, sub_elas_a, 1.)
     @parameter(m, sub_elas_b, 1.)
     @parameter(m, sub_elas_w, 1.)
@@ -171,7 +170,7 @@ end
 
     @production(m, B, 
         ScalarNest(:t; elasticity = t_elas_b, children = [
-            ScalarOutput(PX, diff), 
+            ScalarOutput(PX, diff + 20), 
             ScalarOutput(PY, 80)
         ]),
         ScalarNest(:s; elasticity = sub_elas_b, children = [
@@ -186,7 +185,7 @@ end
             ScalarOutput(PW, 200.0)
         ]),
         ScalarNest(:s; elasticity = sub_elas_w, children = [
-            ScalarInput(PX, diff2), 
+            ScalarInput(PX, diff + 100), 
             ScalarInput(PY, 100.0)
         ])
     )
@@ -229,8 +228,7 @@ end
     @test value(compensated_demand(W,PW, :t))  ≈ -two_by_two_scalar_results["SW.L","benchmark"]#    100.
     @test value(demand(CONS,PW)) ≈ two_by_two_scalar_results["DW.L","benchmark"]#    100.
 
-    set_value!(diff, 10.0 + 20)
-    set_value!(diff2, 10.0 + 100)
+    set_value!(diff, 10.0)
     # set_value!(CONS, 200.0)
     fix(CONS, 200)
     solve!(m)
@@ -373,8 +371,7 @@ end
     "NOTE!! When GAMS version with s:0 for all 3 sectors is not run !FIRST!, these results don't all match. That is, if other sub elasticites were run first,
     and then changed to s:0, GAMS MPSGE gets different results than it does if it starts at s:0. MPSGE.jl does not change results based on the order."
 
-    set_value!(diff, 20)
-    set_value!(diff2, 100)
+    set_value!(diff, 0)
     set_value!(sub_elas_a, 0.0)
     set_value!(sub_elas_b, 0.)
     set_value!(sub_elas_w, 0.)
@@ -405,8 +402,7 @@ end
     @test value(compensated_demand(W,PW, :t))  ≈ -two_by_two_scalar_results["SW.L","benchmark"]#    100.
     @test value(demand(CONS,PW)) ≈ two_by_two_scalar_results["DW.L","benchmark"]#    100.
 
-    set_value!(diff, 10.0 + 20)
-    set_value!(diff2, 10.0 + 100)
+    set_value!(diff, 10.0)
     fix(CONS, 200)
     fix(PW, 1)
     set_value!(sub_elas_a, 1.5)
@@ -549,8 +545,7 @@ end
     # Re-set with CES Substitution Elasticities
     m = MPSGEModel()
 
-    @parameter(m, diff, 20.0)
-    @parameter(m, diff2, 100.0)
+    @parameter(m, diff, 0)
     @parameter(m, sub_elas_a, 1.5)
     @parameter(m, sub_elas_b, 2.)
     @parameter(m, sub_elas_w, .5)
@@ -583,7 +578,7 @@ end
 
     @production(m, B, 
         ScalarNest(:t; elasticity = t_elas_b, children = [
-            ScalarOutput(PX, diff), 
+            ScalarOutput(PX, diff+20), 
             ScalarOutput(PY, 80)
         ]),
         ScalarNest(:s; elasticity = sub_elas_b, children = [
@@ -597,7 +592,7 @@ end
             ScalarOutput(PW, 200.0)
         ]),
         ScalarNest(:s; elasticity = sub_elas_w, children = [
-            ScalarInput(PX, diff2), 
+            ScalarInput(PX, diff + 100), 
             ScalarInput(PY, 100.0)
         ])
     )
@@ -636,8 +631,7 @@ end
     @test value(compensated_demand(W,PW, :t))  ≈ -two_by_two_scalar_results["SW.L","benchmark"]#    100.
     @test value(demand(CONS,PW)) ≈ two_by_two_scalar_results["DW.L","benchmark"]#    100.
 
-    set_value!(diff, 10.0 + 20)
-    set_value!(diff2, 10.0 + 100)
+    set_value!(diff, 10.0)
     fix(PW, 1)
     fix(CONS, 200)
     solve!(m)

--- a/test/test_twobytwo_nested.jl
+++ b/test/test_twobytwo_nested.jl
@@ -5,10 +5,10 @@
     m = MPSGEModel()
     # Here parameter values are doubled and input data halved from MPSGE version
     @parameters(m, begin
-        inputcoeff, 2 * 25
-        endow, 2 * 35
-        elascoeff, 2 * .5
-        outputmult, 2 * 75
+        inputcoeff, 2
+        endow, 2
+        elascoeff, 2
+        outputmult, 2
     end)
 
     @sector(m, U)
@@ -25,14 +25,14 @@
 
     @production(m, U,
         ScalarNest(:t; elasticity = 0, children = [
-            ScalarOutput(PY, outputmult)
+            ScalarOutput(PY, outputmult * 75)
         ]),
         ScalarNest(:s; elasticity = 1, children = [
             ScalarNest(:X; elasticity = 1, children = [
-                ScalarInput(PL, inputcoeff),
+                ScalarInput(PL, inputcoeff * 25),
                 ScalarInput(PK, 50)
             ]),
-            ScalarNest(:Y; elasticity = elascoeff, children = [
+            ScalarNest(:Y; elasticity = elascoeff * .5, children = [
                 ScalarInput(PL, 20),
                 ScalarInput(PK,30)
             ])
@@ -42,7 +42,7 @@
     @demand(m, RA,
         [ScalarDem(PU,150)],
         [
-            ScalarEndowment(PL, endow),
+            ScalarEndowment(PL, endow * 35),
             ScalarEndowment(PK, 80)
         ]
     )

--- a/test/test_twobytwo_wTaxes.jl
+++ b/test/test_twobytwo_wTaxes.jl
@@ -7,7 +7,7 @@
     @parameters(m, begin
         esub_x, 1
         esub_y, 1
-        endow, 70
+        endow, 1
         otax, 0
     end)
 
@@ -61,7 +61,7 @@
     @demand(m, RA, 
         [ScalarDem(PU, 150. )], 
         [
-            ScalarEndowment(PL, endow), 
+            ScalarEndowment(PL, endow*70), 
             ScalarEndowment(PK, 80)
         ]
     )
@@ -291,7 +291,7 @@ end
     @parameters(m, begin
         esub_x, 1
         esub_y, 1
-        endow, 35
+        endow, 1
         otaxa, 0
         otaxb, 0
     end)
@@ -345,7 +345,7 @@ end
         @demand(m, RA[r], 
             [ScalarDem(PU, 75. )], 
             [
-                ScalarEndowment(PL, endow), 
+                ScalarEndowment(PL, endow*35), 
                 ScalarEndowment(PK, 40)
             ]
         )


### PR DESCRIPTION
It's not uncommon to want a quantity to be an expression depending on a parameter. This update allows this.

For example, if `parm` is a parameter, you can now have `elasticity = parm*.5` in a nest.