### PR TITLE
Shadow variables on large cost functions

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -216,7 +216,7 @@ function solve!(m::AbstractMPSGEModel; kwargs...)
         JuMP.set_attribute(jm, string(k), v)
     end
 
-    JuMP.set_optimizer(jm, PATHSolver.Optimizer)
+    #JuMP.set_optimizer(jm, PATHSolver.Optimizer)
 
     consumer = nothing
     #Check numinaire here

--- a/src/production.jl
+++ b/src/production.jl
@@ -187,16 +187,25 @@ function build_cost_function!(N::Node, S::ScalarSector)
         jm = jump_model(model(S))
 
         #This must be an explicit expression, otherwise it's evaluated now. 
-        N.cost_function = @expression(jm, ifelse(
+        cost_function = @expression(jm, ifelse(
                     elasticity(N) * sign == -1,
                     cobb_douglass(N), 
                     CES(N)
                 ))
     elseif elasticity(N)*sign == -1 #Cobb-Douglas is only on demand side with σ=1
-        N.cost_function = cobb_douglass(N)
+        cost_function = cobb_douglass(N)
     else
-        N.cost_function = CES(N)
+        cost_function = CES(N)
     end
+
+    if length(N.children) < 1000
+        N.cost_function = cost_function
+    else
+        jm = jump_model(model(S))
+        N.cost_function = @variable(jm, start = 1) 
+        @constraint(jm, cost_function - N.cost_function ⟂ N.cost_function)
+    end
+
 end
 
 function cobb_douglass(N::Node)#P::ScalarProduction, T::ScalarNest, sign)

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -10,7 +10,7 @@ abstract type MPSGEVariable end
 abstract type MPSGEScalarVariable <: MPSGEVariable end
 
 # Valid types for fields that are quantities
-const MPSGEquantity = Union{Real,MPSGEScalarVariable,JuMP.AffExpr, JuMP.QuadExpr, JuMP.NonlinearExpr}
+const MPSGEquantity = Union{Real,MPSGEScalarVariable, JuMP.VariableRef, JuMP.AffExpr, JuMP.QuadExpr, JuMP.NonlinearExpr}
 
 abstract type MPSGEIndexedVariable{T,N} <: AbstractArray{T,N} end
 


### PR DESCRIPTION
Cost functions have the form

$$\sum_{c\in \text{children}} \frac{Q_c}{Q_{tot}}\cdot CF_c$$

where $Q_c$ is the quantity of child $c$, $Q_{tot}$ is the total quantity of the children and $CF_c$ is the cost function of the child. When a node has a large number of terms (greater than 1000), this cost function becomes large enough to potentially make the computation infeasible. 

The solution is to introduce a shadow variable and constraint. If the variable is named $V$, the constraint is

$$\text{cost function} - V \perp V$$

This simplification greatly reduces memory usage and computation time. 